### PR TITLE
Fix off-by-one error in resetting offsets.

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -371,7 +371,7 @@ public class TopicPartitionWriter {
       CommittedFileFilter filter = new TopicPartitionCommittedFileFilter(tp);
       FileStatus fileStatusWithMaxOffset = FileUtils.fileStatusWithMaxOffset(storage, new Path(path), filter);
       if (fileStatusWithMaxOffset != null) {
-        offset = FileUtils.extractOffset(fileStatusWithMaxOffset.getPath().getName());
+        offset = FileUtils.extractOffset(fileStatusWithMaxOffset.getPath().getName()) + 1;
       }
     } catch (IOException e) {
       throw new ConnectException(e);
@@ -446,13 +446,13 @@ public class TopicPartitionWriter {
     RecordWriter<SinkRecord> writer = getWriter(record, encodedPartition);
     writer.write(record);
     if (offset == -1) {
-      offset = record.kafkaOffset() - 1;
+      offset = record.kafkaOffset();
     }
     if (!startOffsets.containsKey(encodedPartition)) {
-      startOffsets.put(encodedPartition, record.kafkaOffset() - 1);
-      offsets.put(encodedPartition, record.kafkaOffset() - 1);
+      startOffsets.put(encodedPartition, record.kafkaOffset());
+      offsets.put(encodedPartition, record.kafkaOffset());
     } else {
-      offsets.put(encodedPartition, record.kafkaOffset() - 1);
+      offsets.put(encodedPartition, record.kafkaOffset());
     }
     recordCounter++;
   }
@@ -479,8 +479,8 @@ public class TopicPartitionWriter {
     if (!startOffsets.containsKey(encodedPartition)) {
       return;
     }
-    long startOffset = startOffsets.get(encodedPartition) + 1;
-    long endOffset = offsets.get(encodedPartition) + 1;
+    long startOffset = startOffsets.get(encodedPartition);
+    long endOffset = offsets.get(encodedPartition);
     String directory = getDirectory(encodedPartition);
     String committedFile = FileUtils.committedFileName(url, topicsDir, directory, tp, startOffset, endOffset, extension);
     wal.append(tempFile, committedFile);
@@ -518,8 +518,8 @@ public class TopicPartitionWriter {
     if (!startOffsets.containsKey(encodedPartiton)) {
       return;
     }
-    long startOffset = startOffsets.get(encodedPartiton) + 1;
-    long endOffset = offsets.get(encodedPartiton) + 1;
+    long startOffset = startOffsets.get(encodedPartiton);
+    long endOffset = offsets.get(encodedPartiton);
     String tempFile = tempFiles.get(encodedPartiton);
     String directory = getDirectory(encodedPartiton);
     String committedFile = FileUtils.committedFileName(url, topicsDir, directory, tp, startOffset, endOffset, extension);

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
@@ -57,9 +57,9 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
     Map<TopicPartition, Long> offsets = context.offsets();
     assertEquals(offsets.size(), 2);
     assertTrue(offsets.containsKey(TOPIC_PARTITION));
-    assertEquals(20, (long) offsets.get(TOPIC_PARTITION));
+    assertEquals(21, (long) offsets.get(TOPIC_PARTITION));
     assertTrue(offsets.containsKey(TOPIC_PARTITION2));
-    assertEquals(45, (long) offsets.get(TOPIC_PARTITION2));
+    assertEquals(46, (long) offsets.get(TOPIC_PARTITION2));
 
     task.stop();
   }
@@ -104,9 +104,9 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
     Map<TopicPartition, Long> offsets = context.offsets();
     assertEquals(2, offsets.size());
     assertTrue(offsets.containsKey(TOPIC_PARTITION));
-    assertEquals(300, (long) offsets.get(TOPIC_PARTITION));
+    assertEquals(301, (long) offsets.get(TOPIC_PARTITION));
     assertTrue(offsets.containsKey(TOPIC_PARTITION2));
-    assertEquals(800, (long) offsets.get(TOPIC_PARTITION2));
+    assertEquals(801, (long) offsets.get(TOPIC_PARTITION2));
 
     task.stop();
   }

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -124,7 +124,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     hdfsWriter.recover(TOPIC_PARTITION);
     Map<TopicPartition, Long> offsets = context.offsets();
     assertTrue(offsets.containsKey(TOPIC_PARTITION));
-    assertEquals(49L, (long) offsets.get(TOPIC_PARTITION));
+    assertEquals(50L, (long) offsets.get(TOPIC_PARTITION));
 
     String key = "key";
     Schema schema = createSchema();
@@ -210,7 +210,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
 
     assertTrue(committedOffsets.containsKey(TOPIC_PARTITION));
     long previousOffset = committedOffsets.get(TOPIC_PARTITION);
-    assertEquals(previousOffset, 5L);
+    assertEquals(previousOffset, 6L);
 
     hdfsWriter.close();
   }


### PR DESCRIPTION
The offset should be one more than the largest offset found in the filenames
since the offset should be set to the next record to be read. Also get rid of
many +1/-1 adjustments to offset, offsets, and beginOffsets in
TopicPartitionWriter to minimize the number of places we have to adjust offset
information by 1.