### PR TITLE
Ensure the connector always has its own copy of the partition assignment.

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -110,7 +110,7 @@ public class DataWriter {
 
       partitioner = createPartitioner(connectorConfig);
 
-      assignment = context.assignment();
+      assignment = new HashSet<>(context.assignment());
       offsets = new HashMap<>();
       lastAssignment = new HashSet<>();
 
@@ -204,8 +204,7 @@ public class DataWriter {
   }
 
   public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-    assignment.clear();
-    assignment.addAll(partitions);
+    assignment = new HashSet<>(partitions);
 
     // handle partitions that no longer assigned to the task
     for (TopicPartition tp: lastAssignment) {
@@ -234,8 +233,7 @@ public class DataWriter {
   }
 
   public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-    lastAssignment.clear();
-    lastAssignment.addAll(partitions);
+    lastAssignment = new HashSet<>(partitions);
   }
 
   public void close() {

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -43,6 +43,7 @@ import io.confluent.connect.hdfs.storage.StorageFactory;
 import io.confluent.connect.hdfs.wal.WAL;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -279,13 +280,13 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     Set<TopicPartition> newAssignment = new HashSet<>();
     newAssignment.add(TOPIC_PARTITION);
     newAssignment.add(TOPIC_PARTITION3);
-
     hdfsWriter.onPartitionsRevoked(assignment);
-
+    assignment = newAssignment;
     hdfsWriter.onPartitionsAssigned(newAssignment);
-    assertEquals(newAssignment, assignment);
 
     assertEquals(null, hdfsWriter.getBucketWriter(TOPIC_PARTITION2));
+    assertNotNull(hdfsWriter.getBucketWriter(TOPIC_PARTITION));
+    assertNotNull(hdfsWriter.getBucketWriter(TOPIC_PARTITION3));
 
     long[] validOffsetsTopicPartition2 = {5, 6};
     String directory2 = TOPIC + "/" + "partition=" + String.valueOf(PARTITION2);


### PR DESCRIPTION
This addresses two problems. First, it guarantees that even if the set returned
by context.assignment() or in the onPartitionsAssigned/onPartitionsRevoked are
modified, the task still has the correct assignment information. Second, the set
returned by the context.assignment() method is an unmodifiable set and the
existing code was trying to modify it on rebalances. Copying it avoids this
problem.