### PR TITLE
Drop temp files during onPartitionsRevoked to correctly handle rebalance

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -208,6 +208,9 @@ public class DataWriter {
           tp, storage, writerProvider, partitioner, connectorConfig, context, avroData,
           hiveMetaStore, hive, schemaFileReader, executorService, hiveUpdateFutures);
       topicPartitionWriters.put(tp, topicPartitionWriter);
+      // We need to immediately start recovery to ensure we pause consumption of messages for the
+      // assigned topics while we try to recover offsets and rewind.
+      recover(tp);
     }
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -64,7 +64,6 @@ public class DataWriter {
   private RecordWriterProvider writerProvider;
   private SchemaFileReader schemaFileReader;
   private Map<TopicPartition, Long> offsets;
-  private Set<TopicPartition> lastAssignment;
   private HdfsSinkConnectorConfig connectorConfig;
   private AvroData avroData;
   private SinkTaskContext context;
@@ -112,7 +111,6 @@ public class DataWriter {
 
       assignment = new HashSet<>(context.assignment());
       offsets = new HashMap<>();
-      lastAssignment = new HashSet<>();
 
       hiveIntegration = connectorConfig.getBoolean(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG);
       if (hiveIntegration) {
@@ -205,35 +203,32 @@ public class DataWriter {
 
   public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
     assignment = new HashSet<>(partitions);
-
-    // handle partitions that no longer assigned to the task
-    for (TopicPartition tp: lastAssignment) {
-      if (!assignment.contains(tp)) {
-        try {
-          if (topicPartitionWriters.containsKey(tp)) {
-            topicPartitionWriters.get(tp).close();
-          }
-        } catch (ConnectException e) {
-          log.error("Error closing writer for {}. Error: {]", tp, e.getMessage());
-        } finally {
-          topicPartitionWriters.remove(tp);
-        }
-      }
-    }
-
-    // handle new partitions
     for (TopicPartition tp: assignment) {
-      if (!lastAssignment.contains(tp)) {
-        TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-            tp, storage, writerProvider, partitioner, connectorConfig, context, avroData, hiveMetaStore, hive, schemaFileReader, executorService,
-            hiveUpdateFutures);
-        topicPartitionWriters.put(tp, topicPartitionWriter);
-      }
+      TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+          tp, storage, writerProvider, partitioner, connectorConfig, context, avroData,
+          hiveMetaStore, hive, schemaFileReader, executorService, hiveUpdateFutures);
+      topicPartitionWriters.put(tp, topicPartitionWriter);
     }
   }
 
   public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-    lastAssignment = new HashSet<>(partitions);
+    // Close any writers we have. We may get assigned the same partitions and end up duplicating
+    // some effort since we'll have to reprocess those messages. It may be possible to hold on to
+    // the TopicPartitionWriter and continue to use the temp file, but this can get significantly
+    // more complex due to potential failures and network partitions. For example, we may get
+    // this onPartitionsRevoked, then miss a few generations of group membership, during which
+    // data may have continued to be processed and we'd have to restart from the recovery stage,
+    // make sure we apply the WAL, and only reuse the temp file if the starting offset is still
+    // valid. For now, we prefer the simpler solution that may result in a bit of wasted effort.
+    for (TopicPartition tp: assignment) {
+      try {
+        topicPartitionWriters.get(tp).close();
+      } catch (ConnectException e) {
+        log.error("Error closing writer for {}. Error: {]", tp, e.getMessage());
+      } finally {
+        topicPartitionWriters.remove(tp);
+      }
+    }
   }
 
   public void close() {

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
@@ -138,7 +138,8 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
     task.stop();
 
     AvroData avroData = task.getAvroData();
-    long[] validOffsets = {-1, 2, 5, 6};
+    // Last file (offset 6) doesn't satisfy size requirement and gets discarded on close
+    long[] validOffsets = {-1, 2, 5};
 
     for (TopicPartition tp : assignment) {
       String directory = tp.topic() + "/" + "partition=" + String.valueOf(tp.partition());

--- a/src/test/java/io/confluent/connect/hdfs/avro/AvroHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/AvroHiveUtilTest.java
@@ -77,7 +77,8 @@ public class AvroHiveUtilTest extends HiveTestBase {
     String[] expectedResult = {"true", "12", "12", "12.2", "12.2", "12"};
     String result = HiveTestUtils.runHive(hiveExec, "SELECT * FROM " + TOPIC);
     String[] rows = result.split("\n");
-    assertEquals(7, rows.length);
+    // Only 6 of the 7 records should have been delivered due to flush_size = 3
+    assertEquals(6, rows.length);
     for (String row: rows) {
       String[] parts = HiveTestUtils.parseOutput(row);
       for (int j = 0; j < expectedResult.length; ++j) {
@@ -116,7 +117,8 @@ public class AvroHiveUtilTest extends HiveTestBase {
     String[] expectedResult = {"true", "12", "12", "12.2", "12.2", "abc", "12"};
     String result = HiveTestUtils.runHive(hiveExec, "SELECT * from " + TOPIC);
     String[] rows = result.split("\n");
-    assertEquals(7, rows.length);
+    // Only 6 of the 7 records should have been delivered due to flush_size = 3
+    assertEquals(6, rows.length);
     for (String row: rows) {
       String[] parts = HiveTestUtils.parseOutput(row);
       for (int j = 0; j < expectedResult.length; ++j) {

--- a/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
@@ -69,7 +69,8 @@ public class DataWriterParquetTest extends TestWithMiniDFSCluster {
     String encodedPartition = "partition=" + String.valueOf(PARTITION);
     String directory = partitioner.generatePartitionedPath(TOPIC, encodedPartition);
 
-    long[] validOffsets = {-1, 2, 5, 6};
+    // Last file (offset 6) doesn't satisfy size requirement and gets discarded on close
+    long[] validOffsets = {-1, 2, 5};
     for (int i = 1; i < validOffsets.length; i++) {
       long startOffset = validOffsets[i - 1] + 1;
       long endOffset = validOffsets[i];

--- a/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
@@ -88,7 +88,8 @@ public class ParquetHiveUtilTest extends HiveTestBase {
     String[] expectedResult = {"true", "12", "12", "12.2", "12.2", "12"};
     String result = HiveTestUtils.runHive(hiveExec, "SELECT * FROM " + TOPIC);
     String[] rows = result.split("\n");
-    assertEquals(7, rows.length);
+    // Only 6 of the 7 records should have been delivered due to flush_size = 3
+    assertEquals(6, rows.length);
     for (String row: rows) {
       String[] parts = HiveTestUtils.parseOutput(row);
       for (int j = 0; j < expectedResult.length; ++j) {
@@ -127,7 +128,8 @@ public class ParquetHiveUtilTest extends HiveTestBase {
     String[] expectedResult = {"true", "12", "12", "12.2", "12.2", "NULL", "12"};
     String result = HiveTestUtils.runHive(hiveExec, "SELECT * from " + TOPIC);
     String[] rows = result.split("\n");
-    assertEquals(7, rows.length);
+    // Only 6 of the 7 records should have been delivered due to flush_size = 3
+    assertEquals(6, rows.length);
     for (String row: rows) {
       String[] parts = HiveTestUtils.parseOutput(row);
       for (int j = 0; j < expectedResult.length; ++j) {


### PR DESCRIPTION
Instead of trying to hold onto temp files and continue using them if assigned the same partition after rebalance, just drop the temp files immediately because trying to reuse them requires a much more complicated approach and validation of the offsets since the consumer could have missed some generations of group membership.

As fallout of this change, we also no longer save in-progress work when cleanly shutting down the connector, instead always getting files of the requested size. We also validate offsets of records because of KAFKA-2894 which can result in incorrect delivery of messages to connectors that try to reset offsets during a rebalance operation.