### PR TITLE
Add hive.metastore.uris config

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -80,6 +80,11 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
   private static final String HIVE_DATABASE_DOC = "The database to use when writing to hive.";
   private static final String HIVE_DATABASE_DEFAULT = "default";
 
+  public static final String HIVE_METASTORE_URIS_CONFIG = "hive.metastore.uris";
+  private static final String HIVE_METASTORE_URIS_DOC =
+      "The hive metastore URIs, can be IP address (or fully-qualified domain name) and port of the metastore host";
+  public static final String HIVE_METASTORE_URIS_DEFAULT = "";
+
   public static final String SHUTDOWN_TIMEOUT_CONFIG = "shutdown.timeout.ms";
   private static final String SHUTDOWN_TIMEOUT_DOC = "Hive executor clean shutdown timeout.";
   private static final long SHUTDOWN_TIMEOUT_DEFAULT = 3000L;
@@ -136,8 +141,10 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
       .define(RETRY_BACKOFF_CONFIG, Type.LONG, RETRY_BACKOFF_DEFAULT, Importance.HIGH, RETRY_BACKOFF_DOC)
       .define(HIVE_INTEGRATION_CONFIG, Type.BOOLEAN, HIVE_INTEGRATION_DEFAULT, Importance.HIGH, HIVE_INTEGRAtiON_DOC)
       .define(HIVE_HOME_CONFIG, Type.STRING, HIVE_HOME_DEFAULT, Importance.HIGH, HIVE_HOME_DOC)
-      .define(HIVE_CONF_DIR_CONFIG, Type.STRING, HIVE_CONF_DIR_DEFAULT, Importance.HIGH, HIVE_CONF_DIR_DOC)
+      .define(HIVE_CONF_DIR_CONFIG, Type.STRING, HIVE_CONF_DIR_DEFAULT, Importance.HIGH,
+              HIVE_CONF_DIR_DOC)
       .define(HIVE_DATABASE_CONFIG, Type.STRING, HIVE_DATABASE_DEFAULT, Importance.LOW, HIVE_DATABASE_DOC)
+      .define(HIVE_METASTORE_URIS_CONFIG, Type.STRING, HIVE_METASTORE_URIS_DEFAULT, Importance.HIGH, HIVE_METASTORE_URIS_DOC)
       .define(SHUTDOWN_TIMEOUT_CONFIG, Type.LONG, SHUTDOWN_TIMEOUT_DEFAULT,
               Importance.MEDIUM, SHUTDOWN_TIMEOUT_DOC)
       .define(SCHEMA_COMPATIBILITY_CONFIG, Type.STRING, SCHEMA_COMPATIBILITY_DEFAULT,

--- a/src/main/java/io/confluent/connect/hdfs/hive/HiveMetaStore.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/HiveMetaStore.java
@@ -49,7 +49,9 @@ public class HiveMetaStore {
   public HiveMetaStore(Configuration conf, HdfsSinkConnectorConfig connectorConfig) throws HiveMetaStoreException {
     HiveConf hiveConf = new HiveConf(conf, HiveConf.class);
     String hiveConfDir = connectorConfig.getString(HdfsSinkConnectorConfig.HIVE_CONF_DIR_CONFIG);
+    String hiveMetaStoreURIs = connectorConfig.getString(HdfsSinkConnectorConfig.HIVE_METASTORE_URIS_CONFIG);
     hiveConf.addResource(new Path(hiveConfDir, "hive-site.xml"));
+    hiveConf.set("hive.metastore.uris", hiveMetaStoreURIs);
     try {
       client = HCatUtil.getHiveMetastoreClient(hiveConf);
     } catch (IOException | MetaException e) {


### PR DESCRIPTION
We add the hive.metasore.uris config to work around a bug in HiveConf.addResource which can set the value of a configuration back to default. This is needed for connector system test to correctly pick up the right metastore. The documentation for the configurations should be improved and I will address them in later PRs. 
@ewencp Should be a quick review. 