### PR TITLE
Remove close of topic partition writers in DataWriter close

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -269,7 +269,7 @@ public class DataWriter {
     }
   }
 
-  public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+  public void open(Collection<TopicPartition> partitions) {
     assignment = new HashSet<>(partitions);
     for (TopicPartition tp: assignment) {
       TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
@@ -282,12 +282,12 @@ public class DataWriter {
     }
   }
 
-  public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+  public void close(Collection<TopicPartition> partitions) {
     // Close any writers we have. We may get assigned the same partitions and end up duplicating
     // some effort since we'll have to reprocess those messages. It may be possible to hold on to
     // the TopicPartitionWriter and continue to use the temp file, but this can get significantly
     // more complex due to potential failures and network partitions. For example, we may get
-    // this onPartitionsRevoked, then miss a few generations of group membership, during which
+    // this close, then miss a few generations of group membership, during which
     // data may have continued to be processed and we'd have to restart from the recovery stage,
     // make sure we apply the WAL, and only reuse the temp file if the starting offset is still
     // valid. For now, we prefer the simpler solution that may result in a bit of wasted effort.
@@ -302,7 +302,7 @@ public class DataWriter {
     }
   }
 
-  public void close() {
+  public void stop() {
     if (executorService != null) {
       boolean terminated = false;
       try {

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -303,10 +303,6 @@ public class DataWriter {
   }
 
   public void close() {
-    for (TopicPartition tp: assignment) {
-      topicPartitionWriters.get(tp).close();
-    }
-
     if (executorService != null) {
       boolean terminated = false;
       try {

--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -87,7 +87,8 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     content = data.get(logFile);
     assertEquals(6, content.size());
 
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
   }
 
   @Test
@@ -162,7 +163,8 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     }
 
     hdfsWriter.write(new ArrayList<SinkRecord>());
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
   }
 
   @Test
@@ -224,6 +226,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     }
 
     hdfsWriter.write(new ArrayList<SinkRecord>());
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
   }
 }

--- a/src/test/java/io/confluent/connect/hdfs/avro/AvroHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/AvroHiveUtilTest.java
@@ -141,9 +141,10 @@ public class AvroHiveUtilTest extends HiveTestBase {
           new SinkRecord(topic, partition, Schema.STRING_SCHEMA, key, schema, record, offset);
       sinkRecords.add(sinkRecord);
     }
-    hdfsWriter.write(sinkRecords);
 
-    hdfsWriter.close();
+    hdfsWriter.write(sinkRecords);
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
   }
 
   private DataWriter createWriter(SinkTaskContext context, AvroData avroData){

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -294,8 +294,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     Set<TopicPartition> newAssignment = new HashSet<>();
     newAssignment.add(TOPIC_PARTITION);
     newAssignment.add(TOPIC_PARTITION3);
-    hdfsWriter.close(assignment);
 
+    hdfsWriter.close(assignment);
     assignment = newAssignment;
     hdfsWriter.open(newAssignment);
 
@@ -331,7 +331,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     }
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close(assignment);
+    hdfsWriter.close(newAssignment);
     hdfsWriter.stop();
 
     // Last file (offset 9) doesn't satisfy size requirement and gets discarded on close

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -71,7 +70,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
       sinkRecords.add(sinkRecord);
     }
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     String encodedPartition = "partition=" + String.valueOf(PARTITION);
     String directory = partitioner.generatePartitionedPath(TOPIC, encodedPartition);
@@ -140,7 +140,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
           new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 50 + i));
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     committedFiles.add(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION,
                                                    50, 52, extension, ZERO_PAD_FMT));
@@ -172,7 +173,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
       }
     }
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     // Last file (offset 6) doesn't satisfy size requirement and gets discarded on close
     long[] validOffsets = {-1, 2, 5};
@@ -221,7 +223,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     long previousOffset = committedOffsets.get(TOPIC_PARTITION);
     assertEquals(previousOffset, 6L);
 
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
   }
 
   @Test
@@ -242,7 +245,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     }
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     String directory = partitioner.generatePartitionedPath(TOPIC, "partition=" + String.valueOf(PARTITION));
 
@@ -290,9 +294,10 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     Set<TopicPartition> newAssignment = new HashSet<>();
     newAssignment.add(TOPIC_PARTITION);
     newAssignment.add(TOPIC_PARTITION3);
-    hdfsWriter.onPartitionsRevoked(assignment);
+    hdfsWriter.close(assignment);
+
     assignment = newAssignment;
-    hdfsWriter.onPartitionsAssigned(newAssignment);
+    hdfsWriter.open(newAssignment);
 
     assertEquals(null, hdfsWriter.getBucketWriter(TOPIC_PARTITION2));
     assertNotNull(hdfsWriter.getBucketWriter(TOPIC_PARTITION));
@@ -326,7 +331,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     }
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     // Last file (offset 9) doesn't satisfy size requirement and gets discarded on close
     long[] validOffsetsTopicPartition1 = {5, 8};
@@ -386,7 +392,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1L));
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     String DIRECTORY = TOPIC + "/" + "partition=" + String.valueOf(PARTITION);
     Path path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION,
@@ -408,7 +415,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
                                    newRecord, 3L));
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION, 2L,
                                                 3L, extension, ZERO_PAD_FMT));
@@ -442,7 +450,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 2L));
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     String DIRECTORY = TOPIC + "/" + "partition=" + String.valueOf(PARTITION);
     Path path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION,
@@ -467,7 +476,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, 4L));
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION, 3L,
                                                 4L, extension, ZERO_PAD_FMT));
@@ -502,7 +512,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 2L));
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     String DIRECTORY = TOPIC + "/" + "partition=" + String.valueOf(PARTITION);
     Path path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION,
@@ -526,7 +537,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, 4L));
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION, 3L,
                                                 4L, extension, ZERO_PAD_FMT));
@@ -575,8 +587,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     } catch (RuntimeException e) {
       // expected
     }
-
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
   }
 }
 

--- a/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
@@ -67,7 +67,8 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     }
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     Map<String, String> props = createProps();
     props.put(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG, "true");
@@ -96,7 +97,8 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
 
     assertEquals(expectedPartitions, partitions);
 
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
   }
 
   @Test
@@ -119,8 +121,10 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
 
       sinkRecords.add(sinkRecord);
     }
+
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
     List<String> expectedColumnNames = new ArrayList<>();
@@ -169,7 +173,8 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     }
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
 
@@ -244,7 +249,8 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     }
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
 

--- a/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
@@ -64,7 +64,8 @@ public class DataWriterParquetTest extends TestWithMiniDFSCluster {
       sinkRecords.add(sinkRecord);
     }
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     String encodedPartition = "partition=" + String.valueOf(PARTITION);
     String directory = partitioner.generatePartitionedPath(TOPIC, encodedPartition);

--- a/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
@@ -70,7 +70,8 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     }
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     props = createProps();
     props.put(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG, "true");
@@ -99,7 +100,8 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
 
     assertEquals(expectedPartitions, partitions);
 
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
   }
 
   @Test
@@ -123,7 +125,8 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
       sinkRecords.add(sinkRecord);
     }
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
     List<String> expectedColumnNames = new ArrayList<>();
@@ -172,7 +175,8 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     }
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
 
@@ -247,7 +251,8 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     }
 
     hdfsWriter.write(sinkRecords);
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
 

--- a/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
@@ -153,8 +153,8 @@ public class ParquetHiveUtilTest extends HiveTestBase {
       sinkRecords.add(sinkRecord);
     }
     hdfsWriter.write(sinkRecords);
-
-    hdfsWriter.close();
+    hdfsWriter.close(assignment);
+    hdfsWriter.stop();
   }
 
   private DataWriter createWriter(SinkTaskContext context, AvroData avroData) {


### PR DESCRIPTION
@ewencp @hachikuji No need to close writers again as we already have it closed in `onPartitionRevoked`. 