### PR TITLE
In Hive the schema and partition columns must be disjoint sets

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -155,6 +155,7 @@ public class TopicPartitionWriter {
         = "%0" +
           connectorConfig.getInt(HdfsSinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG) +
           "d";
+    lastRotate = System.currentTimeMillis();
 
     hiveIntegration = connectorConfig.getBoolean(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG);
     if (hiveIntegration) {


### PR DESCRIPTION
In Hive the schema and partition columns must be disjoint sets.
btw, method "FieldSchema.equal" doesn't work, cause different FieldSchema.comment. 
There is no comment for fields in schema. when i set "partition.field.name" property in connect config file,partition fields have a comment with empty string "". they don't equal to each other.