### PR TITLE
Bwilliams fix for topics with dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 kafka-connect-hdfs is a [Kafka Connector](http://kafka.apache.org/090/documentation.html#connect)
 for copying data between Kafka and Hadoop HDFS.
 
+# NOTE: 
+ 
+**topics cannot have `+` in their names. If there is, this will not work.** 
+
 # Development
 
 To build a development version you'll need a recent version of Kafka. You can build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for copying data between Kafka and Hadoop HDFS.
 
 # NOTE: 
  
-**topics cannot have `+` in their names. If there is, this will not work.** 
+**topics cannot have `+` in their names. If there is, this will not work. Any other character will work.** 
 
 # Development
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <commons-io.version>2.4</commons-io.version>
         <joda.version>1.6.2</joda.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
 
     <repositories>

--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -151,7 +151,7 @@ public class FileUtils {
   }
 
   public static long extractOffset(String filename) {
-	  String extensionlessFilename = filename.substring(0, filename.lastIndexOf("."));
+    String extensionlessFilename = filename.substring(0, filename.lastIndexOf("."));
     return Long.parseLong(extensionlessFilename.split(HdfsSinkConnecorConstants.COMMMITTED_FILENAME_SEPARATOR_REGEX)[3]);
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -151,7 +151,8 @@ public class FileUtils {
   }
 
   public static long extractOffset(String filename) {
-    return Long.parseLong(filename.split(HdfsSinkConnecorConstants.COMMMITTED_FILENAME_SEPARATOR_REGEX)[3]);
+	  String extensionlessFilename = filename.substring(0, filename.lastIndexOf("."));
+    return Long.parseLong(extensionlessFilename.split(HdfsSinkConnecorConstants.COMMMITTED_FILENAME_SEPARATOR_REGEX)[3]);
   }
 
   private static ArrayList<FileStatus> getDirectoriesImpl(Storage storage, Path path)

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnecorConstants.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnecorConstants.java
@@ -18,7 +18,7 @@ public class HdfsSinkConnecorConstants {
 
   public static final String COMMMITTED_FILENAME_SEPARATOR = "+";
 
-  public static final String COMMMITTED_FILENAME_SEPARATOR_REGEX = "[\\.|\\+]";
+  public static final String COMMMITTED_FILENAME_SEPARATOR_REGEX = "\\+";
 
   // +tmp is a invalid topic name, naming the tmp directory this way to avoid conflicts.
   public static final String TEMPFILE_DIRECTORY = "/+tmp/";

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -291,7 +291,8 @@ public class TopicPartitionWriter {
       } catch (SchemaProjectorException | IllegalWorkerStateException | HiveMetaStoreException e ) {
         throw new RuntimeException(e);
       } catch (IOException | ConnectException e) {
-        log.error("Exception on {}.", tp);
+        log.error("Exception on {}. '{}' ", tp, e.getMessage());
+        e.printStackTrace();
         failureTime = System.currentTimeMillis();
         setRetryTimeout(timeoutMs);
         break;

--- a/src/main/java/io/confluent/connect/hdfs/filter/TopicPartitionCommittedFileFilter.java
+++ b/src/main/java/io/confluent/connect/hdfs/filter/TopicPartitionCommittedFileFilter.java
@@ -31,8 +31,10 @@ public class TopicPartitionCommittedFileFilter extends CommittedFileFilter {
     if (!super.accept(path)) {
       return false;
     }
+
     String filename = path.getName();
-    String[] parts = filename.split(HdfsSinkConnecorConstants.COMMMITTED_FILENAME_SEPARATOR_REGEX);
+    String extensionlessFilename = filename.substring(0, filename.lastIndexOf("."));
+    String[] parts = extensionlessFilename.split(HdfsSinkConnecorConstants.COMMMITTED_FILENAME_SEPARATOR_REGEX);
     String topic = parts[0];
     int partition = Integer.parseInt(parts[1]);
     return topic.equals(tp.topic()) && partition == tp.partition();

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -44,10 +44,12 @@ public class HdfsSinkConnectorTestBase {
 
   protected MockSinkTaskContext context;
   protected static final String TOPIC = "topic";
+  protected static final String TOPIC_V2 = "topic.part2.part3";
   protected static final int PARTITION = 12;
   protected static final int PARTITION2 = 13;
   protected static final int PARTITION3 = 14;
   protected static final TopicPartition TOPIC_PARTITION = new TopicPartition(TOPIC, PARTITION);
+  protected static final TopicPartition TOPIC_PARTITION_V2 = new TopicPartition(TOPIC_V2, PARTITION);
   protected static final TopicPartition TOPIC_PARTITION2 = new TopicPartition(TOPIC, PARTITION2);
   protected static final TopicPartition TOPIC_PARTITION3 = new TopicPartition(TOPIC, PARTITION3);
   protected static Set<TopicPartition> assignment;
@@ -111,6 +113,7 @@ public class HdfsSinkConnectorTestBase {
     assignment = new HashSet<>();
     assignment.add(TOPIC_PARTITION);
     assignment.add(TOPIC_PARTITION2);
+    assignment.add(TOPIC_PARTITION_V2);
     context = new MockSinkTaskContext();
   }
 


### PR DESCRIPTION
If a topic name has a `.` this breaks when attempting to extract the offset. I've refactored the extract logic to first remove the extension and then split by `+` which is used to create the file name. 