### PR TITLE
Init lastRotate to system time

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -155,6 +155,7 @@ public class TopicPartitionWriter {
         = "%0" +
           connectorConfig.getInt(HdfsSinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG) +
           "d";
+    lastRotate = System.currentTimeMillis();
 
     hiveIntegration = connectorConfig.getBoolean(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG);
     if (hiveIntegration) {


### PR DESCRIPTION
Init lastRotate to system time in constructor. The default value of lastRotate is 0, When the first record comes, 'now - lastRotate' is absolutely bigger than rotateIntervalMs. So, kafka connect will write a file with one record into hdfs.