### PR TITLE
Use configured Hadoop configuration object for Parquet writer

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -49,7 +49,7 @@ public class ParquetRecordWriterProvider implements RecordWriterProvider {
 
     Path path = new Path(fileName);
     final ParquetWriter<GenericRecord> writer =
-        new AvroParquetWriter<>(path, avroSchema, compressionCodecName, blockSize, pageSize);
+        new AvroParquetWriter<>(path, avroSchema, compressionCodecName, blockSize, pageSize, true, conf);
 
     return new RecordWriter<SinkRecord>() {
       @Override


### PR DESCRIPTION
## Environment

* We use Cloudera CDH distribution of Hadoop.
* Kafka connect is running in distributed mode on CDH nodes.
* HDFS is set up in high availability mode with logical name `nameservice`.
* Path to HDFS configuration files on each node is `/etc/hadoop/conf` which is managed by CDH manager. Configs are valid and command line hdfs tools work properly with them.
* HDFS Connector property `hadoop.conf.dir` is set up to the path mentioned above, `hdfs.url` is set to `hdfs://nameservice1`.
* HDFS Connector is set up to write data in parquet format.

## Problem

HDFS Sink starts up and recovers partitions from HDFS. When it tries to write to HDFS we get the following exception:

```
    [2016-07-13 14:35:15,221] ERROR Task test-task-connector-0 threw an uncaught and unrecoverable exception (org.apache.kafka.connect.runtime.WorkerSinkTask:390)
java.lang.IllegalArgumentException: java.net.UnknownHostException: nameservice1
    at org.apache.hadoop.security.SecurityUtil.buildTokenService(SecurityUtil.java:374)
    at org.apache.hadoop.hdfs.NameNodeProxies.createNonHAProxy(NameNodeProxies.java:312)
    at org.apache.hadoop.hdfs.NameNodeProxies.createProxy(NameNodeProxies.java:178)
    at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:665)
    at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:601)
    at org.apache.hadoop.hdfs.DistributedFileSystem.initialize(DistributedFileSystem.java:148)
    at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2596)
    at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:91)
    at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2630)
    at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2612)
    at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:370)
    at org.apache.hadoop.fs.Path.getFileSystem(Path.java:296)
```
(this is a bit cut off because I have not copied the whole stacktrace but I can attach it tomorrow after checking our stagin logs again)
    
## Problem analysis 
    
My investigation shows that in order to read data from HDFS a Configuration  object is built into which files `hdfs-site.xml` and `core-site.xml` from a folder specified by `hadoop.conf.dir` are added. This allows the sink to recover data about partitions.
    
When sink wants to write data it constructs an instance of `new AvroParquetWriter<>(path, avroSchema, compressionCodecName, blockSize, pageSize)`. This particular constructor delegates to a bunch of other constructors one of them ultimately builds default Hadoop Configuration instance and uses it to construct HDFS client. This fails since Hadoop config files in my case are outside of classpath.

## Proposed Solution

Pass Hadoop config built for the reader to parquet writer as well so everything behaves as expected.

## Testing

I am not sure how to write an automated test for this case since it requires high availability HDFS setup, I am not sure if it could be constructed using mini HDFS cluster. Do you have any thoughts on it?