### PR TITLE
Upgrade to Hadoop 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <confluent.version>3.1.0-SNAPSHOT</confluent.version>
         <kafka.version>0.10.1.0-SNAPSHOT</kafka.version>
         <junit.version>4.12</junit.version>
-        <hadoop.version>2.6.0</hadoop.version>
+        <hadoop.version>2.6.1</hadoop.version>
         <hive.version>1.2.1</hive.version>
         <avro.version>1.7.7</avro.version>
         <parquet.version>1.7.0</parquet.version>

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -295,7 +295,7 @@ public class DataWriter {
       try {
         topicPartitionWriters.get(tp).close();
       } catch (ConnectException e) {
-        log.error("Error closing writer for {}. Error: {]", tp, e.getMessage());
+        log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
       } finally {
         topicPartitionWriters.remove(tp);
       }


### PR DESCRIPTION
@ewencp There was an issue on Kerberos ticket renew for Java 8 in Hadoop 2.6.0 (https://issues.apache.org/jira/browse/HADOOP-10786). The issue is fixed in 2.6.1. Upgrading to 2.6.1 will fix the issue.