### PR TITLE
Start a new WAL file after `truncate` instead of appending to log.1

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -138,6 +138,9 @@ public class FSWAL implements WAL {
       String oldLogFile = logFile + ".1";
       storage.delete(oldLogFile);
       storage.commit(logFile, oldLogFile);
+      // Clean out references to the current WAL file.
+      // Open a new one on the next lease acquisition.
+      close();
     } catch (IOException e) {
       throw new ConnectException(e);
     }
@@ -148,9 +151,11 @@ public class FSWAL implements WAL {
     try {
       if (writer != null) {
         writer.close();
+        writer = null;
       }
       if (reader != null) {
         reader.close();
+        reader = null;
       }
     } catch (IOException e) {
       throw new ConnectException("Error closing " + logFile, e);

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.hdfs.wal;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+
+import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
+import io.confluent.connect.hdfs.storage.HdfsStorage;
+import io.confluent.connect.hdfs.storage.Storage;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FSWALTest extends TestWithMiniDFSCluster {
+  @Test
+  public void testTruncate() throws Exception {
+    Storage storage = new HdfsStorage(conf, url);
+    TopicPartition tp = new TopicPartition("mytopic", 123);
+    FSWAL wal = new FSWAL("/logs", tp, storage);
+    wal.append("a", "b");
+    assertTrue("WAL file should exist after append",
+            storage.exists("/logs/mytopic/123/log"));
+    wal.truncate();
+    assertFalse("WAL file should not exist after truncate",
+            storage.exists("/logs/mytopic/123/log"));
+    assertTrue("Rotated WAL file should exist after truncate",
+            storage.exists("/logs/mytopic/123/log.1"));
+    wal.append("c", "d");
+    assertTrue("WAL file should be recreated after truncate + append",
+            storage.exists("/logs/mytopic/123/log"));
+    assertTrue("Rotated WAL file should exist after truncate + append",
+            storage.exists("/logs/mytopic/123/log.1"));
+  }
+}


### PR DESCRIPTION
Currently, the code continues appending to log.1, so the next recovery invocation doesn't know about all those WAL entries.

I verified that the regression test fails without the patch.