### PR TITLE
Fix lint annoyances

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,23 @@
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
+                    <compilerArguments>
+                        <Xlint:all/>
+                        <!-- bootstrap class path not set in conjunction with -source 1.7 -->
+                        <Xlint:-options/>
+                        <!-- serializable class ... has no definition of serialVersionUID -->
+                        <Xlint:-serial/>
+                        <!-- bad path element ".../repository/org/apache/derby/derby/10.10.2.0/derbyLocale_*.jar": no such file or directory -->
+                        <Xlint:-path/>
+                        <!--
+                        WALFile.java:[333,16] [deprecation] sync() in Syncable has been deprecated
+                        Apparently SuppressWarnings("deprecation") doesn't cover this on JDK 7
+                        -->
+                        <Xlint:-deprecation/>
+                        <Werror/>
+                    </compilerArguments>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>false</showDeprecation>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -369,11 +369,11 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
       return new LinkedList<>();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public boolean visible(String name, Map<String, Object> connectorConfigs) {
       String partitionerName = (String) connectorConfigs.get(PARTITIONER_CLASS_CONFIG);
       try {
+        @SuppressWarnings("unchecked")
         Class<? extends Partitioner> partitioner = (Class<? extends Partitioner>) Class.forName(partitionerName);
         if (classNameEquals(partitionerName, DefaultPartitioner.class)) {
           return false;

--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -70,7 +70,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     storage.setFailure(MemoryStorage.Failure.appendFailure);
 
     hdfsWriter.write(sinkRecords);
-    assertEquals((long) context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
+    assertEquals(context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
 
     Map<String, List<Object>> data = Data.getData();
 
@@ -121,12 +121,12 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     }
 
     String encodedPartition = "partition=" + String.valueOf(PARTITION);
-    Map<String, RecordWriter> writers = hdfsWriter.getWriters(TOPIC_PARTITION);
+    Map<String, RecordWriter<SinkRecord>> writers = hdfsWriter.getWriters(TOPIC_PARTITION);
     MemoryRecordWriter writer = (MemoryRecordWriter) writers.get(encodedPartition);
     writer.setFailure(MemoryRecordWriter.Failure.writeFailure);
     hdfsWriter.write(sinkRecords);
 
-    assertEquals((long) context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
+    assertEquals(context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
 
     Map<String, List<Object>> data = Data.getData();
     String directory2 = TOPIC + "/" + "partition=" + String.valueOf(PARTITION2);
@@ -143,7 +143,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
 
     writer.setFailure(MemoryRecordWriter.Failure.closeFailure);
     hdfsWriter.write(new ArrayList<SinkRecord>());
-    assertEquals((long) context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
+    assertEquals(context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
 
     Map<String, String> tempFileNames = hdfsWriter.getTempFileNames(TOPIC_PARTITION);
     String tempFileName = tempFileNames.get(encodedPartition);
@@ -190,12 +190,12 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     }
 
     String encodedPartition = "partition=" + String.valueOf(PARTITION);
-    Map<String, RecordWriter> writers = hdfsWriter.getWriters(TOPIC_PARTITION);
+    Map<String, RecordWriter<SinkRecord>> writers = hdfsWriter.getWriters(TOPIC_PARTITION);
     MemoryRecordWriter writer = (MemoryRecordWriter) writers.get(encodedPartition);
 
     writer.setFailure(MemoryRecordWriter.Failure.writeFailure);
     hdfsWriter.write(sinkRecords);
-    assertEquals((long) context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
+    assertEquals(context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
 
     writer.setFailure(MemoryRecordWriter.Failure.closeFailure);
     // nothing happens as we the retry back off hasn't yet passed

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
@@ -174,10 +174,9 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
     fs.createNewFile(new Path(file4));
   }
 
-  @SuppressWarnings("unchecked")
   private void createWALs(Map<TopicPartition, List<String>> tempfiles,
                           Map<TopicPartition, List<String>> committedFiles) throws Exception {
-
+    @SuppressWarnings("unchecked")
     Class<? extends Storage> storageClass = (Class<? extends Storage>)
         Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
     Storage storage = StorageFactory.createStorage(storageClass, conf, url);

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -95,10 +95,10 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testRecovery() throws Exception {
     fs.delete(new Path(FileUtils.directoryName(url, topicsDir, TOPIC_PARTITION)), true);
 
+    @SuppressWarnings("unchecked")
     Class<? extends Storage> storageClass = (Class<? extends Storage>)
         Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
     Storage storage = StorageFactory.createStorage(storageClass, conf, url);

--- a/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
@@ -61,14 +61,15 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
   private static String extension;
 
   @Before
-  @SuppressWarnings("unchecked")
   public void setUp() throws Exception {
     super.setUp();
 
+    @SuppressWarnings("unchecked")
     Format format = ((Class<Format>) Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.FORMAT_CLASS_CONFIG))).newInstance();
     writerProvider = format.getRecordWriterProvider();
     schemaFileReader = format.getSchemaFileReader(avroData);
     extension = writerProvider.getExtension();
+    @SuppressWarnings("unchecked")
     Class<? extends Storage> storageClass = (Class<? extends Storage>) Class
             .forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
     storage = StorageFactory.createStorage(storageClass, conf, url);

--- a/src/test/java/io/confluent/connect/hdfs/wal/WALFileTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/WALFileTest.java
@@ -85,11 +85,11 @@ public class WALFileTest extends TestWithMiniDFSCluster {
 
     WALFile.Reader reader = new WALFile.Reader(conf, WALFile.Reader.file(file));
 
-    assertEquals(key1.getName(), ((WALEntry) reader.next((Object) null)).getName());
-    assertEquals(val1.getName(), ((WALEntry) reader.getCurrentValue((Object) null)).getName());
-    assertEquals(key2.getName(), ((WALEntry) reader.next((Object) null)).getName());
-    assertEquals(val2.getName(), ((WALEntry) reader.getCurrentValue((Object) null)).getName());
-    assertNull(reader.next((Object) null));
+    assertEquals(key1.getName(), reader.next((WALEntry) null).getName());
+    assertEquals(val1.getName(), reader.getCurrentValue(null).getName());
+    assertEquals(key2.getName(), reader.next((WALEntry) null).getName());
+    assertEquals(val2.getName(), reader.getCurrentValue(null).getName());
+    assertNull(reader.next((WALEntry) null));
     reader.close();
   }
 
@@ -107,16 +107,16 @@ public class WALFileTest extends TestWithMiniDFSCluster {
     WALEntry val4 = new WALEntry("val4");
 
     WALFile.Reader reader = new WALFile.Reader(conf, WALFile.Reader.file(file));
-    assertEquals(key1.getName(), ((WALEntry) reader.next((Object) null)).getName());
-    assertEquals(val1.getName(), ((WALEntry) reader.getCurrentValue((Object) null)).getName());
-    assertEquals(key2.getName(), ((WALEntry) reader.next((Object) null)).getName());
-    assertEquals(val2.getName(), ((WALEntry) reader.getCurrentValue((Object) null)).getName());
+    assertEquals(key1.getName(), reader.next((WALEntry) null).getName());
+    assertEquals(val1.getName(), reader.getCurrentValue(null).getName());
+    assertEquals(key2.getName(), reader.next((WALEntry) null).getName());
+    assertEquals(val2.getName(), reader.getCurrentValue(null).getName());
 
-    assertEquals(key3.getName(), ((WALEntry) reader.next((Object) null)).getName());
-    assertEquals(val3.getName(), ((WALEntry) reader.getCurrentValue((Object) null)).getName());
-    assertEquals(key4.getName(), ((WALEntry) reader.next((Object) null)).getName());
-    assertEquals(val4.getName(), ((WALEntry) reader.getCurrentValue((Object) null)).getName());
-    assertNull(reader.next((Object) null));
+    assertEquals(key3.getName(), reader.next((WALEntry) null).getName());
+    assertEquals(val3.getName(), reader.getCurrentValue(null).getName());
+    assertEquals(key4.getName(), reader.next((WALEntry) null).getName());
+    assertEquals(val4.getName(), reader.getCurrentValue(null).getName());
+    assertNull(reader.next((WALEntry) null));
     reader.close();
   }
 }

--- a/src/test/java/io/confluent/connect/hdfs/wal/WALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/WALTest.java
@@ -34,10 +34,10 @@ public class WALTest extends TestWithMiniDFSCluster {
   private static final String extension = ".avro";
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testWALMultiClient() throws Exception {
     fs.delete(new Path(FileUtils.directoryName(url, topicsDir, TOPIC_PARTITION)), true);
 
+    @SuppressWarnings("unchecked")
     Class<? extends Storage> storageClass = (Class<? extends Storage>)
         Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
     Storage storage = StorageFactory.createStorage(storageClass, conf, url);


### PR DESCRIPTION
All the generics changes are elided at compile time, but the WALFile patch changes the interface from Object to WALEntry. I'm not sure why this class was declared to take Object/Writable, since it seems to require WALEntry instances

(Just want to clean up my fork.)