### PR TITLE
adding support for several partition fields not just one 

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/partitioner/FieldPartitioner.java
+++ b/src/main/java/io/confluent/connect/hdfs/partitioner/FieldPartitioner.java
@@ -38,7 +38,11 @@ public class FieldPartitioner implements Partitioner {
   @Override
   public void configure(Map<String, Object> config) {
     fieldName = (String) config.get(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG);
-    partitionFields.add(new FieldSchema(fieldName, TypeInfoFactory.stringTypeInfo.toString(), ""));
+     // adding support to serverl partition fields
+    String[] fields = fieldName.split(",");
+    for(int i =0; i < fields.length ; i++){
+      partitionFields.add(new FieldSchema(fields[i], TypeInfoFactory.stringTypeInfo.toString(), ""));
+    }
   }
 
   @Override


### PR DESCRIPTION
  public void configure(Map<String, Object> config) {
    fieldName = (String) config.get(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG);
     // adding support to serverl partition fields (split by ',')
    String[] fields = fieldName.split(",");
    for(int i =0; i < fields.length ; i++){
      partitionFields.add(new FieldSchema(fields[i], TypeInfoFactory.stringTypeInfo.toString(), ""));
    }
  }