### PR TITLE
Use hsync instead of flush

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -315,7 +315,7 @@ public class WALFile {
         throws IOException {
       out.write(VERSION);                    // write the version
       out.write(sync);                       // write the sync bytes
-      out.flush();                           // flush header
+      out.hsync();                           // flush header
     }
 
 
@@ -328,7 +328,7 @@ public class WALFile {
         if (ownOutputStream) {
           out.close();
         } else {
-          out.flush();
+          out.hsync();
         }
         out = null;
       }


### PR DESCRIPTION
I'm not a HDFS expert, but it looks like flush isn't implemented by DFSOutputStream, HdfsDataOutputStream, or FSDataOutputStream. The only methods declared by the Syncable interface are sync (deprecated), hflush, and hsync.

This should avoid some of the cases where the WAL is empty.