### PR TITLE
Lint change to avoid compiler error in Oracle JDK 1.7 using jenv.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,8 @@
                         Apparently SuppressWarnings("deprecation") doesn't cover this on JDK 7
                         -->
                         <Xlint:-deprecation/>
+                        <!-- Needed for DataWriter.java because @SuppressWarnings("unchecked") doesn't cover this on JDK 7 -->
+                        <Xlint:-unchecked/>
                         <Werror/>
                     </compilerArguments>
                     <showWarnings>true</showWarnings>


### PR DESCRIPTION
@ewencp: this fixed the compiler issue we discussed. It's fixed at least on my machine.