### PR TITLE
minor: remove end offset and clear temp file hash after committing files

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -580,6 +580,7 @@ public class TopicPartitionWriter {
     for (String encodedPartition: tempFiles.keySet()) {
       commitFile(encodedPartition);
     }
+    tempFiles.clear();
   }
 
   private void commitFile(String encodedPartiton) throws IOException {
@@ -600,6 +601,7 @@ public class TopicPartitionWriter {
     }
     storage.commit(tempFile, committedFile);
     startOffsets.remove(encodedPartiton);
+    offsets.remove(encodedPartiton);
     offset = offset + recordCounter;
     recordCounter = 0;
     log.info("Committed {} for {}", committedFile, tp);


### PR DESCRIPTION
I observed end offsets are keeping growing via log[1]. IMHO it's should be cleaned after committing finished.

[1] https://github.com/confluentinc/kafka-connect-hdfs/blob/master/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java#L294