### PR TITLE
Support specifying time field in TimeBasedPartitioner. 

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -14,20 +14,6 @@
 
 package io.confluent.connect.hdfs;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.security.SecurityUtil;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.sink.SinkTaskContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Collection;
@@ -44,6 +30,20 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.hdfs.filter.CommittedFileFilter;
@@ -402,6 +402,7 @@ public class DataWriter {
   private Map<String, Object> copyConfig(HdfsSinkConnectorConfig config) {
     Map<String, Object> map = new HashMap<>();
     map.put(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG, config.getString(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG));
+    map.put(HdfsSinkConnectorConfig.PARTITION_TIME_FIELD_NAME_CONFIG, config.getString(HdfsSinkConnectorConfig.PARTITION_TIME_FIELD_NAME_CONFIG));
     map.put(HdfsSinkConnectorConfig.PARTITION_DURATION_MS_CONFIG, config.getLong(HdfsSinkConnectorConfig.PARTITION_DURATION_MS_CONFIG));
     map.put(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG, config.getString(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG));
     map.put(HdfsSinkConnectorConfig.LOCALE_CONFIG, config.getString(HdfsSinkConnectorConfig.LOCALE_CONFIG));

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -14,17 +14,17 @@
 
 package io.confluent.connect.hdfs;
 
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
-
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 
 import io.confluent.connect.hdfs.partitioner.DailyPartitioner;
 import io.confluent.connect.hdfs.partitioner.DefaultPartitioner;
@@ -190,6 +190,13 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
   public static final String PARTITION_FIELD_NAME_DEFAULT = "";
   public static final String PARTITION_FIELD_NAME_DISPLAY = "Partition Field Name";
 
+  public static final String PARTITION_TIME_FIELD_NAME_CONFIG = "partition.time.field.name";
+  private static final String PARTITION_TIME_FIELD_NAME_DOC =
+          "The timestamp field name of SinkRecord when TimeBasedPartitioner is used, "
+          + "current time will be used on empty";
+  public static final String PARTITION_TIME_FIELD_NAME_DEFAULT = "";
+  public static final String PARTITION_TIME_FIELD_NAME_DISPLAY = "Partition Time Field Name";
+
   public static final String PARTITION_DURATION_MS_CONFIG = "partition.duration.ms";
   private static final String PARTITION_DURATION_MS_DOC =
       "The duration of a partition milliseconds used by ``TimeBasedPartitioner``. "
@@ -305,7 +312,7 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
         .define(RETRY_BACKOFF_CONFIG, Type.LONG, RETRY_BACKOFF_DEFAULT, Importance.LOW, RETRY_BACKOFF_DOC, CONNECTOR_GROUP, 4, Width.SHORT, RETRY_BACKOFF_DISPLAY)
         .define(SHUTDOWN_TIMEOUT_CONFIG, Type.LONG, SHUTDOWN_TIMEOUT_DEFAULT, Importance.MEDIUM, SHUTDOWN_TIMEOUT_DOC, CONNECTOR_GROUP, 5, Width.SHORT, SHUTDOWN_TIMEOUT_DISPLAY)
         .define(PARTITIONER_CLASS_CONFIG, Type.STRING, PARTITIONER_CLASS_DEFAULT, Importance.HIGH, PARTITIONER_CLASS_DOC, CONNECTOR_GROUP, 6, Width.LONG, PARTITIONER_CLASS_DISPLAY,
-                Arrays.asList(PARTITION_FIELD_NAME_CONFIG, PARTITION_DURATION_MS_CONFIG, PATH_FORMAT_CONFIG, LOCALE_CONFIG, TIMEZONE_CONFIG))
+                Arrays.asList(PARTITION_FIELD_NAME_CONFIG, PARTITION_DURATION_MS_CONFIG, PATH_FORMAT_CONFIG, LOCALE_CONFIG, TIMEZONE_CONFIG, PARTITION_TIME_FIELD_NAME_CONFIG))
         .define(PARTITION_FIELD_NAME_CONFIG, Type.STRING, PARTITION_FIELD_NAME_DEFAULT, Importance.MEDIUM, PARTITION_FIELD_NAME_DOC, CONNECTOR_GROUP, 7, Width.MEDIUM,
                 PARTITION_FIELD_NAME_DISPLAY, partitionerClassDependentsRecommender)
         .define(PARTITION_DURATION_MS_CONFIG, Type.LONG, PARTITION_DURATION_MS_DEFAULT, Importance.MEDIUM, PARTITION_DURATION_MS_DOC, CONNECTOR_GROUP, 8, Width.SHORT,
@@ -314,19 +321,21 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
                 partitionerClassDependentsRecommender)
         .define(LOCALE_CONFIG, Type.STRING, LOCALE_DEFAULT, Importance.MEDIUM, LOCALE_DOC, CONNECTOR_GROUP, 10, Width.MEDIUM, LOCALE_DISPLAY, partitionerClassDependentsRecommender)
         .define(TIMEZONE_CONFIG, Type.STRING, TIMEZONE_DEFAULT, Importance.MEDIUM, TIMEZONE_DOC, CONNECTOR_GROUP, 11, Width.MEDIUM, TIMEZONE_DISPLAY, partitionerClassDependentsRecommender)
+        .define(PARTITION_TIME_FIELD_NAME_CONFIG, Type.STRING, PARTITION_TIME_FIELD_NAME_DEFAULT, Importance.MEDIUM, PARTITION_TIME_FIELD_NAME_DOC,
+                CONNECTOR_GROUP, 12, Width.MEDIUM, PARTITION_TIME_FIELD_NAME_DISPLAY, partitionerClassDependentsRecommender)
         .define(FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG, Type.INT, FILENAME_OFFSET_ZERO_PAD_WIDTH_DEFAULT, ConfigDef.Range.atLeast(0), Importance.LOW, FILENAME_OFFSET_ZERO_PAD_WIDTH_DOC,
-                CONNECTOR_GROUP, 12, Width.SHORT, FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY);
+                CONNECTOR_GROUP, 13, Width.SHORT, FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY);
 
     // Define Internal configuration group
     config.define(STORAGE_CLASS_CONFIG, Type.STRING, STORAGE_CLASS_DEFAULT, Importance.LOW, STORAGE_CLASS_DOC, INTERNAL_GROUP, 1, Width.MEDIUM, STORAGE_CLASS_DISPLAY);
   }
 
   private static class SchemaCompatibilityRecommender extends BooleanParentRecommender {
-    
+
     public SchemaCompatibilityRecommender() {
       super(HIVE_INTEGRATION_CONFIG);
     }
-      
+
     @Override
     public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
       boolean hiveIntegration = (Boolean) connectorConfigs.get(parentConfigName);
@@ -342,15 +351,15 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
       return true;
     }
   }
-  
+
   private static class BooleanParentRecommender implements ConfigDef.Recommender {
-    
+
     protected String parentConfigName;
-    
+
     public BooleanParentRecommender(String parentConfigName) {
       this.parentConfigName = parentConfigName;
     }
-    
+
     @Override
     public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
       return new LinkedList<>();
@@ -385,7 +394,7 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
           if (classNameEquals(partitionerName, DailyPartitioner.class) || classNameEquals(partitionerName, HourlyPartitioner.class)) {
             return name.equals(LOCALE_CONFIG) || name.equals(TIMEZONE_CONFIG);
           } else {
-            return name.equals(PARTITION_DURATION_MS_CONFIG) || name.equals(PATH_FORMAT_CONFIG) || name.equals(LOCALE_CONFIG) || name.equals(TIMEZONE_CONFIG);
+            return name.equals(PARTITION_TIME_FIELD_NAME_CONFIG) || name.equals(PARTITION_DURATION_MS_CONFIG) || name.equals(PATH_FORMAT_CONFIG) || name.equals(LOCALE_CONFIG) || name.equals(TIMEZONE_CONFIG);
           }
         } else {
           throw new ConfigException("Not a valid partitioner class: " + partitionerName);

--- a/src/main/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitioner.java
+++ b/src/main/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitioner.java
@@ -14,21 +14,23 @@
 
 package io.confluent.connect.hdfs.partitioner;
 
-import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 
@@ -37,6 +39,7 @@ public class TimeBasedPartitioner implements Partitioner {
   // Duration of a partition in milliseconds.
   private long partitionDurationMs;
   private DateTimeFormatter formatter;
+  private String timeFieldName;
   protected List<FieldSchema> partitionFields = new ArrayList<>();
   private static String patternString = "'year'=Y{1,5}/('month'=M{1,5}/)?('day'=d{1,3}/)?('hour'=H{1,3}/)?('minute'=m{1,3}/)?";
   private static Pattern pattern = Pattern.compile(patternString);
@@ -86,6 +89,8 @@ public class TimeBasedPartitioner implements Partitioner {
     String hiveIntString = (String) config.get(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG);
     boolean hiveIntegration = hiveIntString != null && hiveIntString.toLowerCase().equals("true");
 
+    timeFieldName = (String) config.get(HdfsSinkConnectorConfig.PARTITION_TIME_FIELD_NAME_CONFIG);
+
     Locale locale = new Locale(localeString);
     DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
     init(partitionDurationMs, pathFormat, locale, timeZone, hiveIntegration);
@@ -93,7 +98,21 @@ public class TimeBasedPartitioner implements Partitioner {
 
   @Override
   public String encodePartition(SinkRecord sinkRecord) {
-    long timestamp = System.currentTimeMillis();
+    long timestamp;
+    if (timeFieldName == null || timeFieldName.equals("")) {
+        timestamp = System.currentTimeMillis();
+    } else if (sinkRecord.value() instanceof Struct) {
+        Struct struct = (Struct) sinkRecord.value();
+        if (struct.get(timeFieldName) == null) {
+            throw new DataException(String.format("The time field named '%s' does not exist.", timeFieldName));
+        } else if (struct.get(timeFieldName) instanceof Long) {
+            timestamp = (long) struct.get(timeFieldName);
+        } else {
+            throw new DataException("The value of the time field must be a Long.");
+        }
+    } else {
+        throw new DataException("sinkRecord parameter is expected to be an instance of Struct");
+    }
     DateTime bucket = new DateTime(getPartition(partitionDurationMs, timestamp, formatter.getZone()));
     return bucket.toString(formatter);
   }

--- a/src/main/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitioner.java
+++ b/src/main/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitioner.java
@@ -103,10 +103,14 @@ public class TimeBasedPartitioner implements Partitioner {
         timestamp = System.currentTimeMillis();
     } else if (sinkRecord.value() instanceof Struct) {
         Struct struct = (Struct) sinkRecord.value();
-        if (struct.get(timeFieldName) == null) {
-            throw new DataException(String.format("The time field named '%s' does not exist.", timeFieldName));
-        } else if (struct.get(timeFieldName) instanceof Long) {
-            timestamp = (long) struct.get(timeFieldName);
+        Object timeFieldValue;
+        try {
+            timeFieldValue = struct.get(timeFieldName);
+        } catch (DataException e) {
+            throw new DataException(String.format("The time field named '%s' does not exist.", timeFieldName), e);
+        }
+        if (timeFieldValue instanceof Long) {
+            timestamp = (long) timeFieldValue;
         } else {
             throw new DataException("The value of the time field must be a Long.");
         }

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -16,6 +16,11 @@
 
 package io.confluent.connect.hdfs;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
@@ -24,11 +29,6 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.After;
 import org.junit.Before;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 import io.confluent.connect.avro.AvroData;
 
@@ -95,6 +95,27 @@ public class HdfsSinkConnectorTestBase {
   protected Struct createNewRecord(Schema newSchema) {
     return new Struct(newSchema)
         .put("boolean", true)
+        .put("int", 12)
+        .put("long", 12L)
+        .put("float", 12.2f)
+        .put("double", 12.2)
+        .put("string", "def");
+  }
+
+  protected Schema createSchemaWithTimeField() {
+    return SchemaBuilder.struct().name("record").version(2)
+            .field("timestamp", Schema.INT64_SCHEMA)
+            .field("int", Schema.INT32_SCHEMA)
+            .field("long", Schema.INT64_SCHEMA)
+            .field("float", Schema.FLOAT32_SCHEMA)
+            .field("double", Schema.FLOAT64_SCHEMA)
+            .field("string", SchemaBuilder.string().defaultValue("abc").build())
+            .build();
+  }
+
+  protected Struct createRecordWithTimeField(Schema schema, long timestamp) {
+    return new Struct(schema)
+        .put("timestamp", timestamp)
         .put("int", 12)
         .put("long", 12L)
         .put("float", 12.2f)

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -123,6 +123,14 @@ public class HdfsSinkConnectorTestBase {
         .put("string", "def");
   }
 
+  protected Struct createRecordWithNestedTimeField(long timestamp) {
+      Schema nestedChildSchema = createSchemaWithTimeField();
+      Schema nestedSchema = SchemaBuilder.struct().field("nested", nestedChildSchema);
+      Struct nestedRecord = new Struct(nestedSchema)
+              .put("nested", createRecordWithTimeField(nestedChildSchema, timestamp));
+      return nestedRecord;
+    }
+
   @Before
   public void setUp() throws Exception {
     conf = new Configuration();

--- a/src/test/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitionerTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitionerTest.java
@@ -76,6 +76,19 @@ public class TimeBasedPartitionerTest extends HdfsSinkConnectorTestBase {
   }
 
   @Test
+  public void testGenerateFromNestedTimeField() throws Exception {
+    TimeBasedPartitioner partitioner = new TimeBasedPartitioner();
+    Map<String, Object> config = createConfig("nested.timestamp");
+    partitioner.configure(config);
+    long timestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+    SinkRecord sinkRecord = createSinkRecordWithNestedTimeField(timestamp);
+
+    String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+    assertEquals("year=2015/month=4/day=2/hour=1/", encodedPartition);
+  }
+
+  @Test
   public void testGenerateWithEmptyTimeField() throws Exception {
     TimeBasedPartitioner partitioner = new TimeBasedPartitioner();
     Map<String, Object> config = createConfig(null);
@@ -118,6 +131,11 @@ public class TimeBasedPartitionerTest extends HdfsSinkConnectorTestBase {
       Schema schema = createSchemaWithTimeField();
       Struct record = createRecordWithTimeField(schema, timestamp);
       return new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, schema, record, 0L);
+  }
+
+  private SinkRecord createSinkRecordWithNestedTimeField(long timestamp) {
+      Struct record = createRecordWithNestedTimeField(timestamp);
+      return new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, record.schema(), record, 0L);
   }
 
 }

--- a/src/test/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitionerTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitionerTest.java
@@ -14,19 +14,27 @@
 
 package io.confluent.connect.hdfs.partitioner;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.junit.Test;
 
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.hdfs.HdfsSinkConnectorTestBase;
 
-import static org.junit.Assert.assertEquals;
-
-public class TimeBasedPartitionerTest {
+public class TimeBasedPartitionerTest extends HdfsSinkConnectorTestBase {
   private static final String timeZoneString = "America/Los_Angeles";
   private static final DateTimeZone DATE_TIME_ZONE = DateTimeZone.forID(timeZoneString);
   private BiHourlyPartitioner partitioner = new BiHourlyPartitioner();
@@ -54,6 +62,32 @@ public class TimeBasedPartitionerTest {
     assertEquals(time1.toString(formatter), time2.toString(formatter));
   }
 
+  @Test
+  public void testGenerateFromTimeField() throws Exception {
+    TimeBasedPartitioner partitioner = new TimeBasedPartitioner();
+    Map<String, Object> config = createConfig("timestamp");
+    partitioner.configure(config);
+    long timestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+    SinkRecord sinkRecord = createSinkRecord(timestamp);
+
+    String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+    assertEquals("year=2015/month=4/day=2/hour=1/", encodedPartition);
+  }
+
+  @Test
+  public void testGenerateWithEmptyTimeField() throws Exception {
+    TimeBasedPartitioner partitioner = new TimeBasedPartitioner();
+    Map<String, Object> config = createConfig(null);
+    partitioner.configure(config);
+    long timestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+    SinkRecord sinkRecord = createSinkRecord(timestamp);
+
+    String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+    assertNotEquals("year=2015/month=4/day=2/hour=1/", encodedPartition);
+  }
+
   private static class BiHourlyPartitioner extends TimeBasedPartitioner {
     private static long partitionDurationMs = TimeUnit.HOURS.toMillis(2);
     private static String pathFormat = "'year'=YYYY/'month'=MMMM/'day'=dd/'hour'=H/";
@@ -67,4 +101,23 @@ public class TimeBasedPartitionerTest {
       return pathFormat;
     }
   }
+
+  private Map<String, Object> createConfig(String timeFieldName) {
+      Map<String, Object> config = new HashMap<>();
+      config.put(HdfsSinkConnectorConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.HOURS.toMillis(1));
+      config.put(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG, "'year'=YYYY/'month'=M/'day'=d/'hour'=H/");
+      config.put(HdfsSinkConnectorConfig.LOCALE_CONFIG, Locale.US.toString());
+      config.put(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, DATE_TIME_ZONE.toString());
+      if (timeFieldName != null) {
+          config.put(HdfsSinkConnectorConfig.PARTITION_TIME_FIELD_NAME_CONFIG, timeFieldName);
+      }
+      return config;
+  }
+
+  private SinkRecord createSinkRecord(long timestamp) {
+      Schema schema = createSchemaWithTimeField();
+      Struct record = createRecordWithTimeField(schema, timestamp);
+      return new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, schema, record, 0L);
+  }
+
 }


### PR DESCRIPTION
Tried to solve #98. 

I have started from there https://github.com/confluentinc/kafka-connect-hdfs/pull/109.
I have also added support for time fields located in nested structs of a sink record. 