### PR TITLE
CC-491: Consolidate and simplify unit tests of HDFS connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>
-                    <argLine>-Djava.awt.headless=true</argLine>
+                    <argLine>-Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
                     <forkMode>pertest</forkMode>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,8 @@
                 <version>2.18.1</version>
                 <configuration>
                     <argLine>-Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
-                    <forkMode>pertest</forkMode>
+                    <reuseForks>false</reuseForks>
+                    <forkCount>1</forkCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -56,7 +56,6 @@ public class HdfsSinkConnectorTestBase {
   protected static final TopicPartition TOPIC_WITH_DOTS_PARTITION = new TopicPartition(TOPIC_WITH_DOTS, PARTITION);
   protected static Set<TopicPartition> assignment;
 
-
   protected Map<String, String> createProps() {
     Map<String, String> props = new HashMap<>();
     props.put(HdfsSinkConnectorConfig.HDFS_URL_CONFIG, url);
@@ -77,11 +76,11 @@ public class HdfsSinkConnectorTestBase {
   // Create a batch of records with incremental numeric field values. Total number of records is given by 'size'.
   protected Struct createRecord(Schema schema, int ibase, float fbase) {
     return new Struct(schema)
-               .put("boolean", true)
-               .put("int", ibase)
-               .put("long", (long) ibase)
-               .put("float", fbase)
-               .put("double", (double) fbase);
+        .put("boolean", true)
+        .put("int", ibase)
+        .put("long", (long) ibase)
+        .put("float", fbase)
+        .put("double", (double) fbase);
   }
 
   protected Struct createRecord(Schema schema) {

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -73,7 +73,6 @@ public class HdfsSinkConnectorTestBase {
         .build();
   }
 
-  // Create a batch of records with incremental numeric field values. Total number of records is given by 'size'.
   protected Struct createRecord(Schema schema, int ibase, float fbase) {
     return new Struct(schema)
         .put("boolean", true)
@@ -108,7 +107,8 @@ public class HdfsSinkConnectorTestBase {
         .put("string", "def");
   }
 
-  // Create a batch of records with incremental numeric field values. Total number of records is given by 'size'.
+  // Create a batch of records with incremental numeric field values. Total number of records is
+  // given by 'size'.
   protected List<Struct> createRecordBatch(Schema schema, int size) {
     ArrayList<Struct> records = new ArrayList<>(size);
     int ibase = 16;

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -25,8 +25,10 @@ import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -72,13 +74,18 @@ public class HdfsSinkConnectorTestBase {
         .build();
   }
 
-  protected Struct createRecord(Schema schema) {
+  // Create a batch of records with incremental numeric field values. Total number of records is given by 'size'.
+  protected Struct createRecord(Schema schema, int ibase, float fbase) {
     return new Struct(schema)
-        .put("boolean", true)
-        .put("int", 12)
-        .put("long", 12L)
-        .put("float", 12.2f)
-        .put("double", 12.2);
+               .put("boolean", true)
+               .put("int", ibase)
+               .put("long", (long) ibase)
+               .put("float", fbase)
+               .put("double", (double) fbase);
+  }
+
+  protected Struct createRecord(Schema schema) {
+    return createRecord(schema, 12, 12.2f);
   }
 
   protected Schema createNewSchema() {
@@ -100,6 +107,27 @@ public class HdfsSinkConnectorTestBase {
         .put("float", 12.2f)
         .put("double", 12.2)
         .put("string", "def");
+  }
+
+  // Create a batch of records with incremental numeric field values. Total number of records is given by 'size'.
+  protected List<Struct> createRecordBatch(Schema schema, int size) {
+    ArrayList<Struct> records = new ArrayList<>(size);
+    int ibase = 16;
+    float fbase = 12.2f;
+
+    for (int i = 0; i < size; ++i) {
+      records.add(createRecord(schema, ibase + i, fbase + i));
+    }
+    return records;
+  }
+
+  // Create a list of records by repeating the same record batch. Total number of records: 'batchesNum' x 'batchSize'
+  protected List<Struct> createRecordBatches(Schema schema, int batchSize, int batchesNum) {
+    ArrayList<Struct> records = new ArrayList<>();
+    for (int i = 0; i < batchesNum; ++i) {
+      records.addAll(createRecordBatch(schema, batchSize));
+    }
+    return records;
   }
 
   @Before

--- a/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
@@ -17,18 +17,44 @@
 package io.confluent.connect.hdfs;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.SchemaProjector;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import io.confluent.connect.hdfs.filter.TopicPartitionCommittedFileFilter;
+import io.confluent.connect.hdfs.partitioner.Partitioner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
 
   protected MiniDFSCluster cluster;
   protected FileSystem fs;
+  protected SchemaFileReader schemaFileReader;
+  protected Partitioner partitioner;
+  protected String extension;
+  // The default based on default configuration of 10
+  protected String zeroPadFormat = "%010d";
 
   @Before
   public void setUp() throws Exception {
@@ -69,4 +95,219 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
     props.put(HdfsSinkConnectorConfig.HDFS_URL_CONFIG, url);
     return props;
   }
+
+
+  /**
+   * Return a list of new records starting at zero offset.
+   *
+   * @param size the number of records to return.
+   * @return the list of records.
+   */
+  protected List<SinkRecord> createRecords(int size) {
+    return createRecords(size, 0);
+  }
+
+  /**
+   * Return a list of new records starting at the given offset.
+   *
+   * @param size the number of records to return.
+   * @param startOffset the starting offset.
+   * @return the list of records.
+   */
+  protected List<SinkRecord> createRecords(int size, long startOffset) {
+    return createRecords(size, startOffset, Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
+  }
+
+  /**
+   * Return a list of new records for a set of partitions, starting at the given offset in each partition.
+   *
+   * @param size the number of records to return.
+   * @param startOffset the starting offset.
+   * @param partitions the set of partitions to create records for.
+   * @return the list of records.
+   */
+  protected List<SinkRecord> createRecords(int size, long startOffset, Set<TopicPartition> partitions) {
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (TopicPartition tp : partitions) {
+      for (long offset = startOffset; offset < startOffset + size; ++offset) {
+        sinkRecords.add(new SinkRecord(TOPIC, tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset));
+      }
+    }
+    return sinkRecords;
+  }
+
+  protected List<SinkRecord> createRecordsNoVersion(int size, long startOffset) {
+    String key = "key";
+    Schema schemaNoVersion = SchemaBuilder.struct().name("record")
+                                 .field("boolean", Schema.BOOLEAN_SCHEMA)
+                                 .field("int", Schema.INT32_SCHEMA)
+                                 .field("long", Schema.INT64_SCHEMA)
+                                 .field("float", Schema.FLOAT32_SCHEMA)
+                                 .field("double", Schema.FLOAT64_SCHEMA)
+                                 .build();
+
+    Struct recordNoVersion = new Struct(schemaNoVersion);
+    recordNoVersion.put("boolean", true)
+        .put("int", 12)
+        .put("long", 12L)
+        .put("float", 12.2f)
+        .put("double", 12.2);
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = startOffset; offset < startOffset + size; ++offset) {
+      sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schemaNoVersion,
+                                     recordNoVersion, offset));
+    }
+    return sinkRecords;
+  }
+
+  protected List<SinkRecord> createRecordsWithAlteringSchemas(int size, long startOffset) {
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+    Schema newSchema = createNewSchema();
+    Struct newRecord = createNewRecord(newSchema);
+
+    int limit = (size / 2) * 2;
+    boolean remainder = size % 2 > 0;
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = startOffset; offset < startOffset + limit; ++offset) {
+      sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset));
+      sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, ++offset));
+    }
+    if (remainder) {
+      sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record,
+                                     startOffset + size - 1));
+    }
+    return sinkRecords;
+  }
+
+  protected List<SinkRecord> createRecordsInterleaved(int size, long startOffset, Set<TopicPartition> partitions) {
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = startOffset, total = 0; total < size; ++offset) {
+      for (TopicPartition tp : partitions) {
+        sinkRecords.add(new SinkRecord(TOPIC, tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset));
+        if (++total >= size) {
+          break;
+        }
+      }
+    }
+    return sinkRecords;
+  }
+
+  protected String getDirectory() {
+    return getDirectory(TOPIC, PARTITION);
+  }
+
+  protected String getDirectory(String topic, int partition) {
+    String encodedPartition = "partition=" + String.valueOf(partition);
+    return partitioner.generatePartitionedPath(topic, encodedPartition);
+  }
+
+  /**
+   * Verify files and records are uploaded appropriately.
+   * @param sinkRecords a flat list of the records that need to appear in potentially several files in S3.
+   * @param validOffsets an array containing the offsets that map to uploaded files for a topic-partition.
+   *                     Offsets appear in ascending order, the difference between two consecutive offsets
+   *                     equals the expected size of the file, and last offset is exclusive.
+   */
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets) throws IOException {
+    verify(sinkRecords, validOffsets, Collections.singleton(new TopicPartition(TOPIC, PARTITION)), false);
+  }
+
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions)
+      throws IOException {
+    verify(sinkRecords, validOffsets, partitions, false);
+  }
+
+  /**
+   * Verify files and records are uploaded appropriately.
+   * @param sinkRecords a flat list of the records that need to appear in potentially several files in S3.
+   * @param validOffsets an array containing the offsets that map to uploaded files for a topic-partition.
+   *                     Offsets appear in ascending order, the difference between two consecutive offsets
+   *                     equals the expected size of the file, and last offset is exclusive.
+   * @param partitions the set of partitions to verify records for.
+   */
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,
+                        boolean skipFileListing) throws IOException {
+    if (!skipFileListing) {
+      verifyFileListing(validOffsets, partitions);
+    }
+
+    for (TopicPartition tp : partitions) {
+      for (int i = 1, j = 0; i < validOffsets.length; ++i) {
+        long startOffset = validOffsets[i - 1];
+        long endOffset = validOffsets[i] - 1;
+
+        String filename = FileUtils.committedFileName(url, topicsDir, getDirectory(tp.topic(), tp.partition()), tp,
+                                                      startOffset, endOffset, extension, zeroPadFormat);
+        Path path = new Path(filename);
+        Collection<Object> records = schemaFileReader.readData(conf, path);
+
+        long size = endOffset - startOffset + 1;
+        assertEquals(size, records.size());
+        verifyContents(sinkRecords, j, records);
+        j += size;
+      }
+    }
+  }
+
+  protected List<String> getExpectedFiles(long[] validOffsets, TopicPartition tp) {
+    List<String> expectedFiles = new ArrayList<>();
+    for (int i = 1; i < validOffsets.length; ++i) {
+      long startOffset = validOffsets[i - 1];
+      long endOffset = validOffsets[i] - 1;
+      expectedFiles.add(FileUtils.committedFileName(url, topicsDir, getDirectory(tp.topic(), tp.partition()), tp,
+                                                    startOffset, endOffset, extension, zeroPadFormat));
+    }
+    return expectedFiles;
+  }
+
+  protected void verifyFileListing(long[] validOffsets, Set<TopicPartition> partitions) throws IOException {
+    for (TopicPartition tp : partitions) {
+      verifyFileListing(getExpectedFiles(validOffsets, tp), tp);
+    }
+  }
+
+  protected void verifyFileListing(List<String> expectedFiles, TopicPartition tp) throws IOException {
+    FileStatus[] statuses = {};
+    try {
+      statuses = fs.listStatus(
+          new Path(FileUtils.directoryName(url, topicsDir, getDirectory(tp.topic(), tp.partition()))),
+          new TopicPartitionCommittedFileFilter(tp));
+    } catch (FileNotFoundException e) {
+      // the directory does not exist.
+    }
+
+    List<String> actualFiles = new ArrayList<>();
+    for (FileStatus status : statuses) {
+      actualFiles.add(status.getPath().toString());
+    }
+
+    Collections.sort(actualFiles);
+    Collections.sort(expectedFiles);
+    assertThat(actualFiles, is(expectedFiles));
+  }
+
+  protected void verifyContents(List<SinkRecord> expectedRecords, int startIndex, Collection<Object> records) {
+    Schema expectedSchema = null;
+    for (Object avroRecord : records) {
+      if (expectedSchema == null) {
+        expectedSchema = expectedRecords.get(startIndex).valueSchema();
+      }
+      Object expectedValue = SchemaProjector.project(expectedRecords.get(startIndex).valueSchema(),
+                                                     expectedRecords.get(startIndex++).value(),
+                                                     expectedSchema);
+      assertEquals(avroData.fromConnectData(expectedSchema, expectedValue), avroRecord);
+    }
+  }
+
 }

--- a/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
@@ -240,10 +240,12 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
 
   /**
    * Verify files and records are uploaded appropriately.
-   * @param sinkRecords a flat list of the records that need to appear in potentially several files in S3.
-   * @param validOffsets an array containing the offsets that map to uploaded files for a topic-partition.
-   *                     Offsets appear in ascending order, the difference between two consecutive offsets
-   *                     equals the expected size of the file, and last offset is exclusive.
+   *
+   * @param sinkRecords a flat list of the records that need to appear in potentially several files
+   * in HDFS.
+   * @param validOffsets an array containing the offsets that map to uploaded files for a
+   * topic-partition. Offsets appear in ascending order, the difference between two consecutive
+   * offsets equals the expected size of the file, and last offset is exclusive.
    */
   protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets) throws IOException {
     verify(sinkRecords, validOffsets, Collections.singleton(new TopicPartition(TOPIC, PARTITION)), false);
@@ -256,10 +258,12 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
 
   /**
    * Verify files and records are uploaded appropriately.
-   * @param sinkRecords a flat list of the records that need to appear in potentially several files in S3.
-   * @param validOffsets an array containing the offsets that map to uploaded files for a topic-partition.
-   *                     Offsets appear in ascending order, the difference between two consecutive offsets
-   *                     equals the expected size of the file, and last offset is exclusive.
+   *
+   * @param sinkRecords a flat list of the records that need to appear in potentially several *
+   * files in HDFS.
+   * @param validOffsets an array containing the offsets that map to uploaded files for a
+   * topic-partition. Offsets appear in ascending order, the difference between two consecutive
+   * offsets equals the expected size of the file, and last offset is exclusive.
    * @param partitions the set of partitions to verify records for.
    */
   protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,

--- a/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
@@ -96,15 +96,14 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
     return props;
   }
 
-
   /**
    * Return a list of new records starting at zero offset.
    *
    * @param size the number of records to return.
    * @return the list of records.
    */
-  protected List<SinkRecord> createRecords(int size) {
-    return createRecords(size, 0);
+  protected List<SinkRecord> createSinkRecords(int size) {
+    return createSinkRecords(size, 0);
   }
 
   /**
@@ -114,8 +113,8 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
    * @param startOffset the starting offset.
    * @return the list of records.
    */
-  protected List<SinkRecord> createRecords(int size, long startOffset) {
-    return createRecords(size, startOffset, Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
+  protected List<SinkRecord> createSinkRecords(int size, long startOffset) {
+    return createSinkRecords(size, startOffset, Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
   }
 
   /**
@@ -126,7 +125,8 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
    * @param partitions the set of partitions to create records for.
    * @return the list of records.
    */
-  protected List<SinkRecord> createRecords(int size, long startOffset, Set<TopicPartition> partitions) {
+  protected List<SinkRecord> createSinkRecords(int size, long startOffset, Set<TopicPartition> partitions) {
+    /*
     String key = "key";
     Schema schema = createSchema();
     Struct record = createRecord(schema);
@@ -138,9 +138,35 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
       }
     }
     return sinkRecords;
+    */
+
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+    List<Struct> same = new ArrayList<>();
+    for (int i = 0; i < size; ++i) {
+      same.add(record);
+    }
+    return createSinkRecords(same, schema, startOffset, partitions);
   }
 
-  protected List<SinkRecord> createRecordsNoVersion(int size, long startOffset) {
+  protected List<SinkRecord> createSinkRecords(List<Struct> records, Schema schema) {
+    return createSinkRecords(records, schema, 0, Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
+  }
+
+  protected List<SinkRecord> createSinkRecords(List<Struct> records, Schema schema, long startOffset,
+                                               Set<TopicPartition> partitions) {
+    String key = "key";
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (TopicPartition tp : partitions) {
+      long offset = startOffset;
+      for (Struct record : records) {
+        sinkRecords.add(new SinkRecord(TOPIC, tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset++));
+      }
+    }
+    return sinkRecords;
+  }
+
+  protected List<SinkRecord> createSinkRecordsNoVersion(int size, long startOffset) {
     String key = "key";
     Schema schemaNoVersion = SchemaBuilder.struct().name("record")
                                  .field("boolean", Schema.BOOLEAN_SCHEMA)
@@ -165,7 +191,7 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
     return sinkRecords;
   }
 
-  protected List<SinkRecord> createRecordsWithAlteringSchemas(int size, long startOffset) {
+  protected List<SinkRecord> createSinkRecordsWithAlteringSchemas(int size, long startOffset) {
     String key = "key";
     Schema schema = createSchema();
     Struct record = createRecord(schema);
@@ -186,7 +212,7 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
     return sinkRecords;
   }
 
-  protected List<SinkRecord> createRecordsInterleaved(int size, long startOffset, Set<TopicPartition> partitions) {
+  protected List<SinkRecord> createSinkRecordsInterleaved(int size, long startOffset, Set<TopicPartition> partitions) {
     String key = "key";
     Schema schema = createSchema();
     Struct record = createRecord(schema);

--- a/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
@@ -126,20 +126,6 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
    * @return the list of records.
    */
   protected List<SinkRecord> createSinkRecords(int size, long startOffset, Set<TopicPartition> partitions) {
-    /*
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    List<SinkRecord> sinkRecords = new ArrayList<>();
-    for (TopicPartition tp : partitions) {
-      for (long offset = startOffset; offset < startOffset + size; ++offset) {
-        sinkRecords.add(new SinkRecord(TOPIC, tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset));
-      }
-    }
-    return sinkRecords;
-    */
-
     Schema schema = createSchema();
     Struct record = createRecord(schema);
     List<Struct> same = new ArrayList<>();
@@ -191,7 +177,7 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
     return sinkRecords;
   }
 
-  protected List<SinkRecord> createSinkRecordsWithAlteringSchemas(int size, long startOffset) {
+  protected List<SinkRecord> createSinkRecordsWithAlternatingSchemas(int size, long startOffset) {
     String key = "key";
     Schema schema = createSchema();
     Struct record = createRecord(schema);

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -35,15 +35,20 @@ import io.confluent.connect.hdfs.storage.Storage;
 import io.confluent.connect.hdfs.storage.StorageFactory;
 import io.confluent.connect.hdfs.wal.WAL;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -52,47 +57,23 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   private static final String extension = ".avro";
   private static final String ZERO_PAD_FMT = "%010d";
   private SchemaFileReader schemaFileReader = new AvroFileReader(avroData);
-  
+  Partitioner partitioner;
+
   @Test
   public void testWriteRecord() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    Partitioner partitioner = hdfsWriter.getPartitioner();
+    partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
+    List<SinkRecord> sinkRecords = createRecords(7);
 
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    for (long offset = 0; offset < 7; offset++) {
-      SinkRecord sinkRecord =
-          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
-
-      sinkRecords.add(sinkRecord);
-    }
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
 
-    String encodedPartition = "partition=" + String.valueOf(PARTITION);
-    String directory = partitioner.generatePartitionedPath(TOPIC, encodedPartition);
-
     // Last file (offset 6) doesn't satisfy size requirement and gets discarded on close
-    long[] validOffsets = {-1, 2, 5};
-    for (int i = 1; i < validOffsets.length; i++) {
-      long startOffset = validOffsets[i - 1] + 1;
-      long endOffset = validOffsets[i];
-      Path path =
-          new Path(FileUtils
-                       .committedFileName(url, topicsDir, directory, TOPIC_PARTITION, startOffset,
-                                          endOffset, extension, ZERO_PAD_FMT));
-      Collection<Object> records = schemaFileReader.readData(conf, path);
-      long size = endOffset - startOffset + 1;
-      assertEquals(size, records.size());
-      for (Object avroRecord : records) {
-        assertEquals(avroData.fromConnectData(schema, record), avroRecord);
-      }
-    }
+    long[] validOffsets = {0, 3, 6};
+    verify(sinkRecords, validOffsets);
   }
 
   @Test
@@ -103,99 +84,58 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     Class<? extends Storage> storageClass = (Class<? extends Storage>)
         Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
     Storage storage = StorageFactory.createStorage(storageClass, conf, url);
+    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
 
     WAL wal = storage.wal(logsDir, TOPIC_PARTITION);
 
     wal.append(WAL.beginMarker, "");
-    Set<String> committedFiles = new HashSet<>();
-
-    String directory = TOPIC + "/" + "partition=" + String.valueOf(PARTITION);
 
     for (int i = 0; i < 5; ++i) {
       long startOffset = i * 10;
       long endOffset = (i + 1) * 10 - 1;
-      String tempfile = FileUtils.tempFileName(url, topicsDir, directory, extension);
+      String tempfile = FileUtils.tempFileName(url, topicsDir, getDirectory(), extension);
       fs.createNewFile(new Path(tempfile));
-      String committedFile = FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, startOffset,
+      String committedFile = FileUtils.committedFileName(url, topicsDir, getDirectory(), TOPIC_PARTITION, startOffset,
                                                          endOffset, extension, ZERO_PAD_FMT);
-      committedFiles.add(committedFile);
       wal.append(tempfile, committedFile);
     }
     wal.append(WAL.endMarker, "");
     wal.close();
 
-    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
     hdfsWriter.recover(TOPIC_PARTITION);
     Map<TopicPartition, Long> offsets = context.offsets();
     assertTrue(offsets.containsKey(TOPIC_PARTITION));
     assertEquals(50L, (long) offsets.get(TOPIC_PARTITION));
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    // Need enough records to trigger file rotation
-    ArrayList<SinkRecord> sinkRecords = new ArrayList<>();
-    for (int i = 0; i < 3; i++)
-      sinkRecords.add(
-          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 50 + i));
+    List<SinkRecord> sinkRecords = createRecords(3, 50);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
 
-    committedFiles.add(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION,
-                                                   50, 52, extension, ZERO_PAD_FMT));
-    FileStatus[] statuses = fs.listStatus(new Path(FileUtils.directoryName(url, topicsDir, directory)),
-                      new TopicPartitionCommittedFileFilter(TOPIC_PARTITION));
-    assertEquals(committedFiles.size(), statuses.length);
-    for (FileStatus status : statuses) {
-      assertTrue(committedFiles.contains(status.getPath().toString()));
-    }
+    long[] validOffsets = {0, 10, 20, 30, 40, 50, 53};
+    verifyFileListing(validOffsets, Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
   }
 
   @Test
   public void testWriteRecordMultiplePartitions() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
 
     for (TopicPartition tp: assignment) {
       hdfsWriter.recover(tp);
     }
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
 
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    for (TopicPartition tp: assignment) {
-      for (long offset = 0; offset < 7; offset++) {
-        SinkRecord sinkRecord =
-            new SinkRecord(tp.topic(), tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset);
-        sinkRecords.add(sinkRecord);
-      }
-    }
+    List<SinkRecord> sinkRecords = createRecords(7, 0, assignment);
+
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
 
     // Last file (offset 6) doesn't satisfy size requirement and gets discarded on close
-    long[] validOffsets = {-1, 2, 5};
-
-    for (TopicPartition tp : assignment) {
-      String directory = tp.topic() + "/" + "partition=" + String.valueOf(tp.partition());
-      for (int j = 1; j < validOffsets.length; ++j) {
-        long startOffset = validOffsets[j - 1] + 1;
-        long endOffset = validOffsets[j];
-        Path path = new Path(
-            FileUtils.committedFileName(url, topicsDir, directory, tp, startOffset, endOffset,
-                                        extension, ZERO_PAD_FMT));
-        Collection<Object> records = schemaFileReader.readData(conf, path);
-        long size = endOffset - startOffset + 1;
-        assertEquals(records.size(), size);
-        for (Object avroRecord : records) {
-          assertEquals(avroRecord, avroData.fromConnectData(schema, record));
-        }
-      }
-    }
+    long[] validOffsets = {0, 3, 6};
+    verify(sinkRecords, validOffsets, assignment);
   }
 
   @Test
@@ -229,65 +169,33 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   }
 
   @Test
-  public void testWriteRecordNonZeroInitailOffset() throws Exception {
+  public void testWriteRecordNonZeroInitialOffset() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    Partitioner partitioner = hdfsWriter.getPartitioner();
+    partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    for (long offset = 3; offset < 10; offset++) {
-      SinkRecord sinkRecord =
-          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
-      sinkRecords.add(sinkRecord);
-    }
+    List<SinkRecord> sinkRecords = createRecords(7, 3);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
 
-    String directory = partitioner.generatePartitionedPath(TOPIC, "partition=" + String.valueOf(PARTITION));
-
     // Last file (offset 9) doesn't satisfy size requirement and gets discarded on close
-    long[] validOffsets = {2, 5, 8};
-    for (int i = 1; i < validOffsets.length; i++) {
-      long startOffset = validOffsets[i - 1] + 1;
-      long endOffset = validOffsets[i];
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, directory,
-                                                       TOPIC_PARTITION, startOffset, endOffset,
-                                                       extension, ZERO_PAD_FMT));
-      Collection<Object> records = schemaFileReader.readData(conf, path);
-      long size = endOffset - startOffset + 1;
-      assertEquals(size, records.size());
-      for (Object avroRecord : records) {
-        assertEquals(avroData.fromConnectData(schema, record), avroRecord);
-      }
-    }
+    long[] validOffsets = {3, 6, 9};
+    verify(sinkRecords, validOffsets);
   }
 
   @Test
   public void testRebalance() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
 
     // Initial assignment is {TP1, TP2}
     for (TopicPartition tp: assignment) {
       hdfsWriter.recover(tp);
     }
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
 
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    for (TopicPartition tp: assignment) {
-      for (long offset = 0; offset < 7; offset++) {
-        SinkRecord sinkRecord =
-            new SinkRecord(tp.topic(), tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset);
-        sinkRecords.add(sinkRecord);
-      }
-    }
+    List<SinkRecord> sinkRecords = createRecords(7, 0, assignment);
     hdfsWriter.write(sinkRecords);
 
     Set<TopicPartition> oldAssignment = new HashSet<>(assignment);
@@ -305,71 +213,25 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     assertNotNull(hdfsWriter.getBucketWriter(TOPIC_PARTITION3));
 
     // Last file (offset 6) doesn't satisfy size requirement and gets discarded on close
-    long[] validOffsetsTopicPartition2 = {-1, 2, 5};
-    String directory2 = TOPIC + "/" + "partition=" + String.valueOf(PARTITION2);
-    for (int j = 1; j < validOffsetsTopicPartition2.length; ++j) {
-      long startOffset = validOffsetsTopicPartition2[j - 1] + 1;
-      long endOffset = validOffsetsTopicPartition2[j];
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, directory2,
-                                                       TOPIC_PARTITION2, startOffset, endOffset,
-                                                       extension, ZERO_PAD_FMT));
-      Collection<Object> records = schemaFileReader.readData(conf, path);
-      long size = endOffset - startOffset + 1;
-      assertEquals(records.size(), size);
-      for (Object avroRecord : records) {
-        assertEquals(avroData.fromConnectData(schema, record), avroRecord);
-      }
-    }
+    long[] validOffsetsTopicPartition2 = {0, 3, 6};
+    verify(sinkRecords, validOffsetsTopicPartition2, Collections.singleton(TOPIC_PARTITION2), true);
 
-    sinkRecords.clear();
-    for (TopicPartition tp: assignment) {
-      // Message offsets start at 6 because we discarded the in-progress temp file on rebalance
-      for (long offset = 6; offset < 10; offset++) {
-        SinkRecord sinkRecord =
-            new SinkRecord(tp.topic(), tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset);
-        sinkRecords.add(sinkRecord);
-      }
-    }
+    // Message offsets start at 6 because we discarded the in-progress temp file on re-balance
+    sinkRecords = createRecords(3, 6, assignment);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(newAssignment);
     hdfsWriter.stop();
 
     // Last file (offset 9) doesn't satisfy size requirement and gets discarded on close
-    long[] validOffsetsTopicPartition1 = {5, 8};
-    String directory1 = TOPIC + "/" + "partition=" + String.valueOf(PARTITION);
-    for (int j = 1; j < validOffsetsTopicPartition1.length; ++j) {
-      long startOffset = validOffsetsTopicPartition1[j - 1] + 1;
-      long endOffset = validOffsetsTopicPartition1[j];
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, directory1 ,
-                                                       TOPIC_PARTITION, startOffset, endOffset,
-                                                       extension, ZERO_PAD_FMT));
-      Collection<Object> records = schemaFileReader.readData(conf, path);
-      long size = endOffset - startOffset + 1;
-      assertEquals(records.size(), size);
-      for (Object avroRecord : records) {
-        assertEquals(avroData.fromConnectData(schema, record), avroRecord);
-      }
-    }
+    long[] validOffsetsTopicPartition1 = {6, 9};
+    verify(sinkRecords, validOffsetsTopicPartition1, Collections.singleton(TOPIC_PARTITION), true);
 
-    long[] validOffsetsTopicPartition3 = {5, 8};
-    String directory3 = TOPIC + "/" + "partition=" + String.valueOf(PARTITION3);
-    for (int j = 1; j < validOffsetsTopicPartition3.length; ++j) {
-      long startOffset = validOffsetsTopicPartition3[j - 1] + 1;
-      long endOffset = validOffsetsTopicPartition3[j];
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, directory3,
-                                                       TOPIC_PARTITION3, startOffset, endOffset,
-                                                       extension, ZERO_PAD_FMT));
-      Collection<Object> records = schemaFileReader.readData(conf, path);
-      long size = endOffset - startOffset + 1;
-      assertEquals(records.size(), size);
-      for (Object avroRecord : records) {
-        assertEquals(avroData.fromConnectData(schema, record), avroRecord);
-      }
-    }
+    long[] validOffsetsTopicPartition3 = {6, 9};
+    verify(sinkRecords, validOffsetsTopicPartition3, Collections.singleton(TOPIC_PARTITION3), true);
+
     assignment = oldAssignment;
   }
-
 
   @Test
   public void testProjectBackWard() throws Exception {
@@ -379,53 +241,16 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    Schema newSchema = createNewSchema();
-    Struct newRecord = createNewRecord(newSchema);
-
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, 0L));
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1L));
+    List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(7, 0);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
-
-    String DIRECTORY = TOPIC + "/" + "partition=" + String.valueOf(PARTITION);
-    Path path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION,
-                                                     0L, 1L, extension, ZERO_PAD_FMT));
-    ArrayList<Object> records = (ArrayList<Object>) schemaFileReader.readData(conf, path);
-    assertEquals(2, records.size());
-
-    assertEquals(avroData.fromConnectData(newSchema, newRecord), records.get(0));
-
-    Object projected = SchemaProjector.project(schema, record, newSchema);
-    assertEquals(avroData.fromConnectData(newSchema, projected), records.get(1));
-
-    hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
-
-    sinkRecords.clear();
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 2L));
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema,
-                                   newRecord, 3L));
-
-    hdfsWriter.write(sinkRecords);
-    hdfsWriter.close(assignment);
-    hdfsWriter.stop();
-
-    path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION, 2L,
-                                                3L, extension, ZERO_PAD_FMT));
-    records = (ArrayList<Object>) schemaFileReader.readData(conf, path);
-    assertEquals(2, records.size());
-
-    assertEquals(avroData.fromConnectData(newSchema, projected), records.get(0));
-    assertEquals(avroData.fromConnectData(newSchema, newRecord), records.get(1));
+    long[] validOffsets = {0, 1, 3, 5, 7};
+    verify(sinkRecords, validOffsets);
   }
 
   @Test
@@ -435,58 +260,17 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    Schema newSchema = createNewSchema();
-    Struct newRecord = createNewRecord(newSchema);
-
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, 0L));
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1L));
-    // Include one more to get to forced file rotation
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 2L));
+    List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(7, 0);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
 
-    String DIRECTORY = TOPIC + "/" + "partition=" + String.valueOf(PARTITION);
-    Path path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION,
-                                                     0L, 0L, extension, ZERO_PAD_FMT));
-    ArrayList<Object> records = (ArrayList<Object>) schemaFileReader.readData(conf, path);
-    assertEquals(1, records.size());
-
-
-    assertEquals(avroData.fromConnectData(newSchema, newRecord), records.get(0));
-
-    path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION, 1L,
-                                                2L, extension, ZERO_PAD_FMT));
-    records = (ArrayList<Object>) schemaFileReader.readData(conf, path);
-    assertEquals(avroData.fromConnectData(schema, record), records.get(0));
-    assertEquals(avroData.fromConnectData(schema, record), records.get(1));
-
-    hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
-
-    sinkRecords.clear();
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, 3L));
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, 4L));
-
-    hdfsWriter.write(sinkRecords);
-    hdfsWriter.close(assignment);
-    hdfsWriter.stop();
-
-    path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION, 3L,
-                                                4L, extension, ZERO_PAD_FMT));
-    records = (ArrayList<Object>) schemaFileReader.readData(conf, path);
-    assertEquals(2, records.size());
-
-    assertEquals(avroData.fromConnectData(newSchema, newRecord), records.get(0));
-    assertEquals(avroData.fromConnectData(newSchema, newRecord), records.get(1));
+    long[] validOffsets = {0, 1, 2, 3, 4, 5, 6};
+    verify(sinkRecords, validOffsets);
   }
 
   @Test
@@ -497,99 +281,44 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    Schema newSchema = createNewSchema();
-    Struct newRecord = createNewRecord(newSchema);
-
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, 0L));
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1L));
-    // Include one more to get to forced file rotation
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 2L));
+    // By excluding the first element we get a list starting with record having the new schema.
+    List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(8, 0).subList(1, 8);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
 
-    String DIRECTORY = TOPIC + "/" + "partition=" + String.valueOf(PARTITION);
-    Path path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION,
-                                                     0L, 0L, extension, ZERO_PAD_FMT));
-    ArrayList<Object> records = (ArrayList<Object>) schemaFileReader.readData(conf, path);
-    assertEquals(1, records.size());
-
-    assertEquals(avroData.fromConnectData(newSchema, newRecord), records.get(0));
-
-    path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION, 1L,
-                                                2L, extension, ZERO_PAD_FMT));
-    records = (ArrayList<Object>) schemaFileReader.readData(conf, path);
-    assertEquals(avroData.fromConnectData(schema, record), records.get(0));
-    assertEquals(avroData.fromConnectData(schema, record), records.get(1));
-
-    hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
-
-    sinkRecords.clear();
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, 3L));
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, 4L));
-
-    hdfsWriter.write(sinkRecords);
-    hdfsWriter.close(assignment);
-    hdfsWriter.stop();
-
-    path = new Path(FileUtils.committedFileName(url, topicsDir, DIRECTORY, TOPIC_PARTITION, 3L,
-                                                4L, extension, ZERO_PAD_FMT));
-    records = (ArrayList<Object>) schemaFileReader.readData(conf, path);
-    assertEquals(2, records.size());
-
-    assertEquals(avroData.fromConnectData(schema, record), records.get(0));
-    assertEquals(avroData.fromConnectData(schema, record), records.get(1));
+    long[] validOffsets = {1, 2, 4, 6, 8};
+    verify(sinkRecords, validOffsets);
   }
 
   @Test
   public void testProjectNoVersion() throws Exception {
-    Schema schemaNoVersion = SchemaBuilder.struct().name("record")
-        .field("boolean", Schema.BOOLEAN_SCHEMA)
-        .field("int", Schema.INT32_SCHEMA)
-        .field("long", Schema.INT64_SCHEMA)
-        .field("float", Schema.FLOAT32_SCHEMA)
-        .field("double", Schema.FLOAT64_SCHEMA)
-        .build();
-
-    Struct recordNoVersion = new Struct(schemaNoVersion);
-    recordNoVersion.put("boolean", true)
-        .put("int", 12)
-        .put("long", 12L)
-        .put("float", 12.2f)
-        .put("double", 12.2);
-
     Map<String, String> props = createProps();
     props.put(HdfsSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "BACKWARD");
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schemaNoVersion, recordNoVersion, 0L));
-    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1L));
+    List<SinkRecord> sinkRecords = createRecordsNoVersion(1, 0);
+    sinkRecords.addAll(createRecordsWithAlteringSchemas(7, 0));
 
     try {
       hdfsWriter.write(sinkRecords);
       fail("Version is required for Backward compatibility.");
     } catch (RuntimeException e) {
       // expected
+    } finally {
+      hdfsWriter.close(assignment);
+      hdfsWriter.stop();
+      long[] validOffsets = {};
+      verify(Collections.<SinkRecord>emptyList(), validOffsets);
     }
-    hdfsWriter.close(assignment);
-    hdfsWriter.stop();
   }
 
   @Test
@@ -600,7 +329,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
 
     String FLUSH_SIZE_CONFIG = "10";
     // send 1.5 * FLUSH_SIZE_CONFIG records
-    long NUMBER_OF_RECORD = Long.valueOf(FLUSH_SIZE_CONFIG) + Long.valueOf(FLUSH_SIZE_CONFIG) / 2;
+    int NUMBER_OF_RECORDS = Integer.valueOf(FLUSH_SIZE_CONFIG) + Integer.valueOf(FLUSH_SIZE_CONFIG) / 2;
 
     Map<String, String> props = createProps();
     props.put(HdfsSinkConnectorConfig.FLUSH_SIZE_CONFIG, FLUSH_SIZE_CONFIG);
@@ -610,17 +339,10 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     assignment.add(TOPIC_PARTITION);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    for (long offset = 0; offset < NUMBER_OF_RECORD; offset++) {
-      SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
-      sinkRecords.add(sinkRecord);
-    }
+    List<SinkRecord> sinkRecords = createRecords(NUMBER_OF_RECORDS);
     hdfsWriter.write(sinkRecords);
 
     // wait for rotation to happen
@@ -634,10 +356,223 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedOffsets();
     assertTrue(committedOffsets.containsKey(TOPIC_PARTITION));
     long previousOffset = committedOffsets.get(TOPIC_PARTITION);
-    assertEquals(NUMBER_OF_RECORD, previousOffset);
+    assertEquals(NUMBER_OF_RECORDS, previousOffset);
 
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
+  }
+
+  /**
+   * Return a list of new records starting at zero offset.
+   *
+   * @param size the number of records to return.
+   * @return the list of records.
+   */
+  protected List<SinkRecord> createRecords(int size) {
+    return createRecords(size, 0);
+  }
+
+  /**
+   * Return a list of new records starting at the given offset.
+   *
+   * @param size the number of records to return.
+   * @param startOffset the starting offset.
+   * @return the list of records.
+   */
+  protected List<SinkRecord> createRecords(int size, long startOffset) {
+    return createRecords(size, startOffset, Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
+  }
+
+  /**
+   * Return a list of new records for a set of partitions, starting at the given offset in each partition.
+   *
+   * @param size the number of records to return.
+   * @param startOffset the starting offset.
+   * @param partitions the set of partitions to create records for.
+   * @return the list of records.
+   */
+  protected List<SinkRecord> createRecords(int size, long startOffset, Set<TopicPartition> partitions) {
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (TopicPartition tp : partitions) {
+      for (long offset = startOffset; offset < startOffset + size; ++offset) {
+        sinkRecords.add(new SinkRecord(TOPIC, tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset));
+      }
+    }
+    return sinkRecords;
+  }
+
+  protected List<SinkRecord> createRecordsNoVersion(int size, long startOffset) {
+    String key = "key";
+    Schema schemaNoVersion = SchemaBuilder.struct().name("record")
+                                 .field("boolean", Schema.BOOLEAN_SCHEMA)
+                                 .field("int", Schema.INT32_SCHEMA)
+                                 .field("long", Schema.INT64_SCHEMA)
+                                 .field("float", Schema.FLOAT32_SCHEMA)
+                                 .field("double", Schema.FLOAT64_SCHEMA)
+                                 .build();
+
+    Struct recordNoVersion = new Struct(schemaNoVersion);
+    recordNoVersion.put("boolean", true)
+        .put("int", 12)
+        .put("long", 12L)
+        .put("float", 12.2f)
+        .put("double", 12.2);
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = startOffset; offset < startOffset + size; ++offset) {
+      sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schemaNoVersion,
+                                     recordNoVersion, offset));
+    }
+    return sinkRecords;
+  }
+
+  protected List<SinkRecord> createRecordsWithAlteringSchemas(int size, long startOffset) {
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+    Schema newSchema = createNewSchema();
+    Struct newRecord = createNewRecord(newSchema);
+
+    int limit = (size / 2) * 2;
+    boolean remainder = size % 2 > 0;
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = startOffset; offset < startOffset + limit; ++offset) {
+      sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset));
+      sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, newSchema, newRecord, ++offset));
+    }
+    if (remainder) {
+      sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record,
+                                     startOffset + size - 1));
+    }
+    return sinkRecords;
+  }
+
+  protected List<SinkRecord> createRecordsInterleaved(int size, long startOffset, Set<TopicPartition> partitions) {
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = startOffset, total = 0; total < size; ++offset) {
+      for (TopicPartition tp : partitions) {
+        sinkRecords.add(new SinkRecord(TOPIC, tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset));
+        if (++total >= size) {
+          break;
+        }
+      }
+    }
+    return sinkRecords;
+  }
+
+  protected String getDirectory() {
+    return getDirectory(TOPIC, PARTITION);
+  }
+
+  protected String getDirectory(String topic, int partition) {
+    String encodedPartition = "partition=" + String.valueOf(partition);
+    return partitioner.generatePartitionedPath(topic, encodedPartition);
+  }
+
+  /**
+   * Verify files and records are uploaded appropriately.
+   * @param sinkRecords a flat list of the records that need to appear in potentially several files in S3.
+   * @param validOffsets an array containing the offsets that map to uploaded files for a topic-partition.
+   *                     Offsets appear in ascending order, the difference between two consecutive offsets
+   *                     equals the expected size of the file, and last offset is exclusive.
+   */
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets) throws IOException {
+    verify(sinkRecords, validOffsets, Collections.singleton(new TopicPartition(TOPIC, PARTITION)), false);
+  }
+
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions)
+      throws IOException {
+    verify(sinkRecords, validOffsets, partitions, false);
+  }
+
+  /**
+   * Verify files and records are uploaded appropriately.
+   * @param sinkRecords a flat list of the records that need to appear in potentially several files in S3.
+   * @param validOffsets an array containing the offsets that map to uploaded files for a topic-partition.
+   *                     Offsets appear in ascending order, the difference between two consecutive offsets
+   *                     equals the expected size of the file, and last offset is exclusive.
+   * @param partitions the set of partitions to verify records for.
+   */
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,
+                        boolean skipFileListing) throws IOException {
+    if (!skipFileListing) {
+      verifyFileListing(validOffsets, partitions);
+    }
+
+    for (TopicPartition tp : partitions) {
+      for (int i = 1, j = 0; i < validOffsets.length; ++i) {
+        long startOffset = validOffsets[i - 1];
+        long endOffset = validOffsets[i] - 1;
+
+        String filename = FileUtils.committedFileName(url, topicsDir, getDirectory(tp.topic(), tp.partition()), tp,
+                                                      startOffset, endOffset, extension, ZERO_PAD_FMT);
+        Path path = new Path(filename);
+        Collection<Object> records = schemaFileReader.readData(conf, path);
+
+        long size = endOffset - startOffset + 1;
+        assertEquals(size, records.size());
+        verifyContents(sinkRecords, j, records);
+        j += size;
+      }
+    }
+  }
+
+  protected List<String> getExpectedFiles(long[] validOffsets, TopicPartition tp) {
+    List<String> expectedFiles = new ArrayList<>();
+    for (int i = 1; i < validOffsets.length; ++i) {
+      long startOffset = validOffsets[i - 1];
+      long endOffset = validOffsets[i] - 1;
+      expectedFiles.add(FileUtils.committedFileName(url, topicsDir, getDirectory(tp.topic(), tp.partition()), tp,
+                                                    startOffset, endOffset, extension, ZERO_PAD_FMT));
+    }
+    return expectedFiles;
+  }
+
+  protected void verifyFileListing(long[] validOffsets, Set<TopicPartition> partitions) throws IOException {
+    for (TopicPartition tp : partitions) {
+      verifyFileListing(getExpectedFiles(validOffsets, tp), tp);
+    }
+  }
+
+  protected void verifyFileListing(List<String> expectedFiles, TopicPartition tp) throws IOException {
+    FileStatus[] statuses = {};
+    try {
+      statuses = fs.listStatus(
+          new Path(FileUtils.directoryName(url, topicsDir, getDirectory(tp.topic(), tp.partition()))),
+          new TopicPartitionCommittedFileFilter(tp));
+    } catch (FileNotFoundException e) {
+      // the directory does not exist.
+    }
+
+    List<String> actualFiles = new ArrayList<>();
+    for (FileStatus status : statuses) {
+      actualFiles.add(status.getPath().toString());
+    }
+
+    Collections.sort(actualFiles);
+    Collections.sort(expectedFiles);
+    assertThat(actualFiles, is(expectedFiles));
+  }
+
+  protected void verifyContents(List<SinkRecord> expectedRecords, int startIndex, Collection<Object> records) {
+    Schema expectedSchema = null;
+    for (Object avroRecord : records) {
+      if (expectedSchema == null) {
+        expectedSchema = expectedRecords.get(startIndex).valueSchema();
+      }
+      Object expectedValue = SchemaProjector.project(expectedRecords.get(startIndex).valueSchema(),
+                                                     expectedRecords.get(startIndex++).value(),
+                                                     expectedSchema);
+      assertEquals(avroData.fromConnectData(expectedSchema, expectedValue), avroRecord);
+    }
   }
 
 }

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -55,7 +55,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    List<SinkRecord> sinkRecords = createRecords(7);
+    List<SinkRecord> sinkRecords = createSinkRecords(7);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -98,7 +98,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     assertTrue(offsets.containsKey(TOPIC_PARTITION));
     assertEquals(50L, (long) offsets.get(TOPIC_PARTITION));
 
-    List<SinkRecord> sinkRecords = createRecords(3, 50);
+    List<SinkRecord> sinkRecords = createSinkRecords(3, 50);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -117,7 +117,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
       hdfsWriter.recover(tp);
     }
 
-    List<SinkRecord> sinkRecords = createRecords(7, 0, assignment);
+    List<SinkRecord> sinkRecords = createSinkRecords(7, 0, assignment);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -164,7 +164,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    List<SinkRecord> sinkRecords = createRecords(7, 3);
+    List<SinkRecord> sinkRecords = createSinkRecords(7, 3);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -185,7 +185,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
       hdfsWriter.recover(tp);
     }
 
-    List<SinkRecord> sinkRecords = createRecords(7, 0, assignment);
+    List<SinkRecord> sinkRecords = createSinkRecords(7, 0, assignment);
     hdfsWriter.write(sinkRecords);
 
     Set<TopicPartition> oldAssignment = new HashSet<>(assignment);
@@ -207,7 +207,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     verify(sinkRecords, validOffsetsTopicPartition2, Collections.singleton(TOPIC_PARTITION2), true);
 
     // Message offsets start at 6 because we discarded the in-progress temp file on re-balance
-    sinkRecords = createRecords(3, 6, assignment);
+    sinkRecords = createSinkRecords(3, 6, assignment);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(newAssignment);
@@ -234,7 +234,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(7, 0);
+    List<SinkRecord> sinkRecords = createSinkRecordsWithAlteringSchemas(7, 0);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -253,7 +253,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(7, 0);
+    List<SinkRecord> sinkRecords = createSinkRecordsWithAlteringSchemas(7, 0);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -275,7 +275,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     hdfsWriter.recover(TOPIC_PARTITION);
 
     // By excluding the first element we get a list starting with record having the new schema.
-    List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(8, 0).subList(1, 8);
+    List<SinkRecord> sinkRecords = createSinkRecordsWithAlteringSchemas(8, 0).subList(1, 8);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -295,8 +295,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    List<SinkRecord> sinkRecords = createRecordsNoVersion(1, 0);
-    sinkRecords.addAll(createRecordsWithAlteringSchemas(7, 0));
+    List<SinkRecord> sinkRecords = createSinkRecordsNoVersion(1, 0);
+    sinkRecords.addAll(createSinkRecordsWithAlteringSchemas(7, 0));
 
     try {
       hdfsWriter.write(sinkRecords);
@@ -332,7 +332,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    List<SinkRecord> sinkRecords = createRecords(NUMBER_OF_RECORDS);
+    List<SinkRecord> sinkRecords = createSinkRecords(NUMBER_OF_RECORDS);
     hdfsWriter.write(sinkRecords);
 
     // wait for rotation to happen

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -268,7 +268,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    List<SinkRecord> sinkRecords = createSinkRecordsWithAlteringSchemas(7, 0);
+    List<SinkRecord> sinkRecords = createSinkRecordsWithAlternatingSchemas(7, 0);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -287,7 +287,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    List<SinkRecord> sinkRecords = createSinkRecordsWithAlteringSchemas(7, 0);
+    List<SinkRecord> sinkRecords = createSinkRecordsWithAlternatingSchemas(7, 0);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -309,7 +309,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     hdfsWriter.recover(TOPIC_PARTITION);
 
     // By excluding the first element we get a list starting with record having the new schema.
-    List<SinkRecord> sinkRecords = createSinkRecordsWithAlteringSchemas(8, 0).subList(1, 8);
+    List<SinkRecord> sinkRecords = createSinkRecordsWithAlternatingSchemas(8, 0).subList(1, 8);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -330,7 +330,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecordsNoVersion(1, 0);
-    sinkRecords.addAll(createSinkRecordsWithAlteringSchemas(7, 0));
+    sinkRecords.addAll(createSinkRecordsWithAlternatingSchemas(7, 0));
 
     try {
       hdfsWriter.write(sinkRecords);

--- a/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +37,6 @@ import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.Format;
 import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import io.confluent.connect.hdfs.RecordWriterProvider;
-import io.confluent.connect.hdfs.SchemaFileReader;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
 import io.confluent.connect.hdfs.TopicPartitionWriter;
 import io.confluent.connect.hdfs.filter.CommittedFileFilter;
@@ -81,11 +81,11 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
         TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, avroData);
 
-    String key = "key";
     Schema schema = createSchema();
-    Struct[] records = createRecords(schema);
-
-    Collection<SinkRecord> sinkRecords = createSinkRecords(records, key, schema);
+    List<Struct> records = createRecordBatches(schema, 3, 3);
+    // Add a single records at the end of the batches sequence. Total records: 10
+    records.add(createRecord(schema));
+    List<SinkRecord> sinkRecords = createSinkRecords(records, schema);
 
     for (SinkRecord record : sinkRecords) {
       topicPartitionWriter.buffer(record);
@@ -102,7 +102,8 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
                                "/" + TOPIC + "+" + PARTITION + "+03+05" + extension));
     expectedFiles.add(new Path(url + "/" + topicsDir + "/" + TOPIC + "/partition=" + PARTITION +
                                "/" + TOPIC + "+" + PARTITION + "+06+08" + extension));
-    verify(expectedFiles, records, schema);
+    int expectedBatchSize = 3;
+    verify(expectedFiles, expectedBatchSize, records, schema);
   }
 
 
@@ -117,11 +118,17 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
         TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, avroData);
 
-    String key = "key";
     Schema schema = createSchema();
-    Struct[] records = createRecords(schema);
+    List<Struct> records = new ArrayList<>();
+    for (int i = 16; i < 19; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        records.add(createRecord(schema, i, 12.2f));
 
-    Collection<SinkRecord> sinkRecords = createSinkRecords(records, key, schema);
+      }
+    }
+    // Add a single records at the end of the batches sequence. Total records: 10
+    records.add(createRecord(schema));
+    List<SinkRecord> sinkRecords = createSinkRecords(records, schema);
 
     for (SinkRecord record : sinkRecords) {
       topicPartitionWriter.buffer(record);
@@ -130,7 +137,6 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     topicPartitionWriter.recover();
     topicPartitionWriter.write();
     topicPartitionWriter.close();
-
 
     String directory1 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(16));
     String directory2 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(17));
@@ -141,7 +147,8 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory2, TOPIC_PARTITION, 3, 5, extension, zeroPadFormat)));
     expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory3, TOPIC_PARTITION, 6, 8, extension, zeroPadFormat)));
 
-    verify(expectedFiles, records, schema);
+    int expectedBatchSize = 3;
+    verify(expectedFiles, expectedBatchSize, records, schema);
   }
 
   @Test
@@ -153,11 +160,11 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
         TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, avroData);
 
-    String key = "key";
     Schema schema = createSchema();
-    Struct[] records = createRecords(schema);
-
-    Collection<SinkRecord> sinkRecords = createSinkRecords(records, key, schema);
+    List<Struct> records = createRecordBatches(schema, 3, 3);
+    // Add a single records at the end of the batches sequence. Total records: 10
+    records.add(createRecord(schema));
+    List<SinkRecord> sinkRecords = createSinkRecords(records, schema);
 
     for (SinkRecord record : sinkRecords) {
       topicPartitionWriter.buffer(record);
@@ -166,7 +173,6 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     topicPartitionWriter.recover();
     topicPartitionWriter.write();
     topicPartitionWriter.close();
-
 
     long partitionDurationMs = (Long) config.get(HdfsSinkConnectorConfig.PARTITION_DURATION_MS_CONFIG);
     String pathFormat = (String) config.get(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG);
@@ -182,7 +188,8 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 3, 5, extension, zeroPadFormat)));
     expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 6, 8, extension, zeroPadFormat)));
 
-    verify(expectedFiles, records, schema);
+    int expectedBatchSize = 3;
+    verify(expectedFiles, expectedBatchSize, records, schema);
   }
 
   private Map<String, Object> createConfig() {
@@ -209,51 +216,7 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     }
   }
 
-  private Struct[] createRecords(Schema schema) {
-    Struct record1 = new Struct(schema)
-        .put("boolean", true)
-        .put("int", 16)
-        .put("long", 12L)
-        .put("float", 12.2f)
-        .put("double", 12.2);
-
-    Struct record2 = new Struct(schema)
-        .put("boolean", true)
-        .put("int", 17)
-        .put("long", 12L)
-        .put("float", 12.2f)
-        .put("double", 12.2);
-
-    Struct record3 = new Struct(schema)
-        .put("boolean", true)
-        .put("int", 18)
-        .put("long", 12L)
-        .put("float", 12.2f)
-        .put("double", 12.2);
-
-    ArrayList<Struct> records = new ArrayList<>();
-    records.add(record1);
-    records.add(record2);
-    records.add(record3);
-    return records.toArray(new Struct[records.size()]);
-  }
-
-
-  private ArrayList<SinkRecord> createSinkRecords(Struct[] records, String key, Schema schema) {
-    ArrayList<SinkRecord> sinkRecords = new ArrayList<>();
-    long offset = 0;
-    for (Struct record : records) {
-      for (long count = 0; count < 3; count++) {
-        SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record,
-                                               offset + count);
-        sinkRecords.add(sinkRecord);
-      }
-      offset = offset + 3;
-    }
-    return sinkRecords;
-  }
-
-  private void verify(Set<Path> expectedFiles, Struct[] records, Schema schema) throws IOException {
+  private void verify(Set<Path> expectedFiles, int expectedSize, List<Struct> records, Schema schema) throws IOException {
     Path path = new Path(FileUtils.topicDirectory(url, topicsDir, TOPIC));
     FileStatus[] statuses = FileUtils.traverse(storage, path, new CommittedFileFilter());
     assertEquals(expectedFiles.size(), statuses.length);
@@ -262,11 +225,11 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
       Path filePath = status.getPath();
       assertTrue(expectedFiles.contains(status.getPath()));
       Collection<Object> avroRecords = schemaFileReader.readData(conf, filePath);
-      assertEquals(3, avroRecords.size());
-      for (Object avroRecord: avroRecords) {
-        assertEquals(avroData.fromConnectData(schema, records[index]), avroRecord);
+      assertEquals(expectedSize, avroRecords.size());
+      for (Object avroRecord : avroRecords) {
+        assertEquals(avroData.fromConnectData(schema, records.get(index++)), avroRecord);
       }
-      index++;
     }
   }
+
 }

--- a/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
@@ -52,13 +52,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
-  // The default based on default configuration of 10
-  private static final String ZERO_PAD_FMT = "%010d";
-
   private RecordWriterProvider writerProvider;
-  private SchemaFileReader schemaFileReader;
   private Storage storage;
-  private static String extension;
 
   @Before
   public void setUp() throws Exception {
@@ -142,9 +137,9 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     String directory3 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(18));
 
     Set<Path> expectedFiles = new HashSet<>();
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory1, TOPIC_PARTITION, 0, 2, extension, ZERO_PAD_FMT)));
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory2, TOPIC_PARTITION, 3, 5, extension, ZERO_PAD_FMT)));
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory3, TOPIC_PARTITION, 6, 8, extension, ZERO_PAD_FMT)));
+    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory1, TOPIC_PARTITION, 0, 2, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory2, TOPIC_PARTITION, 3, 5, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory3, TOPIC_PARTITION, 6, 8, extension, zeroPadFormat)));
 
     verify(expectedFiles, records, schema);
   }
@@ -183,9 +178,9 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     String directory = partitioner.generatePartitionedPath(TOPIC, encodedPartition);
 
     Set<Path> expectedFiles = new HashSet<>();
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 0, 2, extension, ZERO_PAD_FMT)));
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 3, 5, extension, ZERO_PAD_FMT)));
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 6, 8, extension, ZERO_PAD_FMT)));
+    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 0, 2, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 3, 5, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 6, 8, extension, zeroPadFormat)));
 
     verify(expectedFiles, records, schema);
   }

--- a/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
@@ -15,29 +15,26 @@
 package io.confluent.connect.hdfs.parquet;
 
 
-import org.apache.hadoop.fs.Path;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import io.confluent.connect.hdfs.DataWriter;
-import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
-import io.confluent.connect.hdfs.SchemaFileReader;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
 import io.confluent.connect.hdfs.partitioner.Partitioner;
 
-import static org.junit.Assert.assertEquals;
-
 public class DataWriterParquetTest extends TestWithMiniDFSCluster {
-  private static final String ZERO_PAD_FMT = "%010d";
-  private static final String extension = ".parquet";
-  private final SchemaFileReader schemaFileReader = new ParquetFileReader(avroData);
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    schemaFileReader = new ParquetFileReader(avroData);
+    extension = ".parquet";
+  }
 
   @Override
   protected Map<String, String> createProps() {
@@ -49,41 +46,17 @@ public class DataWriterParquetTest extends TestWithMiniDFSCluster {
   @Test
   public void testWriteRecord() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    Partitioner partitioner = hdfsWriter.getPartitioner();
+    partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
+    List<SinkRecord> sinkRecords = createRecords(7);
 
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    for (long offset = 0; offset < 7; offset++) {
-      SinkRecord sinkRecord =
-          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
-
-      sinkRecords.add(sinkRecord);
-    }
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
 
-    String encodedPartition = "partition=" + String.valueOf(PARTITION);
-    String directory = partitioner.generatePartitionedPath(TOPIC, encodedPartition);
-
     // Last file (offset 6) doesn't satisfy size requirement and gets discarded on close
-    long[] validOffsets = {-1, 2, 5};
-    for (int i = 1; i < validOffsets.length; i++) {
-      long startOffset = validOffsets[i - 1] + 1;
-      long endOffset = validOffsets[i];
-      Path path = new Path(
-          FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, startOffset,
-                                      endOffset, extension, ZERO_PAD_FMT));
-      Collection<Object> records = schemaFileReader.readData(conf, path);
-      long size = endOffset - startOffset + 1;
-      assertEquals(size, records.size());
-      for (Object avroRecord : records) {
-        assertEquals(avroData.fromConnectData(schema, record), avroRecord);
-      }
-    }
+    long[] validOffsets = {0, 3, 6};
+    verify(sinkRecords, validOffsets);
   }
 }

--- a/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
@@ -49,7 +49,7 @@ public class DataWriterParquetTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    List<SinkRecord> sinkRecords = createRecords(7);
+    List<SinkRecord> sinkRecords = createSinkRecords(7);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);

--- a/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
@@ -277,7 +277,6 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
       String[] parts = HiveTestUtils.parseOutput(rows[i]);
       int j = 0;
       for (String expectedValue : expectedResults.get(i)) {
-        System.err.println("Exp: " + expectedValue + " Actual: " + parts[j]);
         assertEquals(expectedValue, parts[j++]);
       }
     }

--- a/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
@@ -25,7 +25,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -58,16 +58,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    for (long offset = 0; offset < 7; offset++) {
-      SinkRecord sinkRecord =
-          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
-      sinkRecords.add(sinkRecord);
-    }
+    List<SinkRecord> sinkRecords = createSinkRecords(7);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -80,14 +71,18 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     hdfsWriter = new DataWriter(config, context, avroData);
     hdfsWriter.syncWithHive();
 
+    Schema schema = createSchema();
+    Struct expectedRecord = createRecord(schema);
+    List<String> expectedResult = new ArrayList<>();
     List<String> expectedColumnNames = new ArrayList<>();
-    for (Field field: schema.fields()) {
+    for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
+      expectedResult.add(String.valueOf(expectedRecord.get(field.name())));
     }
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
     List<String> actualColumnNames = new ArrayList<>();
-    for (FieldSchema column: table.getSd().getCols()) {
+    for (FieldSchema column : table.getSd().getCols()) {
       actualColumnNames.add(column.getName());
     }
     assertEquals(expectedColumnNames, actualColumnNames);
@@ -113,29 +108,21 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     DataWriter hdfsWriter = new DataWriter(config, context, avroData);
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
+    List<SinkRecord> sinkRecords = createSinkRecords(7);
 
-    Collection<SinkRecord> sinkRecords = new ArrayList<>();
-    for (long offset = 0; offset < 7; offset++) {
-      SinkRecord sinkRecord =
-          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
-
-      sinkRecords.add(sinkRecord);
-    }
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
     hdfsWriter.stop();
 
+    Schema schema = createSchema();
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
     List<String> expectedColumnNames = new ArrayList<>();
-    for (Field field: schema.fields()) {
+    for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
     }
 
     List<String> actualColumnNames = new ArrayList<>();
-    for (FieldSchema column: table.getSd().getCols()) {
+    for (FieldSchema column : table.getSd().getCols()) {
       actualColumnNames.add(column.getName());
     }
     assertEquals(expectedColumnNames, actualColumnNames);
@@ -159,20 +146,9 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     HdfsSinkConnectorConfig config = new HdfsSinkConnectorConfig(props);
     DataWriter hdfsWriter = new DataWriter(config, context, avroData);
 
-    String key = "key";
     Schema schema = createSchema();
-
-    Struct[] records = createRecords(schema);
-    ArrayList<SinkRecord> sinkRecords = new ArrayList<>();
-    long offset = 0;
-    for (Struct record : records) {
-      for (long count = 0; count < 3; count++) {
-        SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record,
-                                               offset + count);
-        sinkRecords.add(sinkRecord);
-      }
-      offset = offset + 3;
-    }
+    List<Struct> records = createRecordBatches(schema, 3, 3);
+    List<SinkRecord> sinkRecords = createSinkRecords(records, schema);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -181,16 +157,15 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
 
     List<String> expectedColumnNames = new ArrayList<>();
-    for (Field field: schema.fields()) {
+    for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
     }
 
     List<String> actualColumnNames = new ArrayList<>();
-    for (FieldSchema column: table.getSd().getCols()) {
+    for (FieldSchema column : table.getSd().getCols()) {
       actualColumnNames.add(column.getName());
     }
     assertEquals(expectedColumnNames, actualColumnNames);
-
 
     String partitionFieldName = config.getString(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG);
     String directory1 = TOPIC + "/" + partitionFieldName + "=" + String.valueOf(16);
@@ -206,20 +181,25 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
 
     assertEquals(expectedPartitions, partitions);
 
-    ArrayList<String[]> expectedResult = new ArrayList<>();
-    for (int i = 16; i <= 18; ++i) {
-      String[] part = {"true", String.valueOf(i), "12", "12.2", "12.2"};
+    List<List<String>> expectedResults = new ArrayList<>();
+    for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
-        expectedResult.add(part);
+        List<String> result = new ArrayList<>();
+        for (Field field : schema.fields()) {
+          result.add(String.valueOf(records.get(i).get(field.name())));
+        }
+        expectedResults.add(result);
       }
     }
+
     String result = HiveTestUtils.runHive(hiveExec, "SELECT * FROM " + TOPIC);
     String[] rows = result.split("\n");
     assertEquals(9, rows.length);
     for (int i = 0; i < rows.length; ++i) {
       String[] parts = HiveTestUtils.parseOutput(rows[i]);
-      for (int j = 0; j < expectedResult.get(i).length; ++j) {
-        assertEquals(expectedResult.get(i)[j], parts[j]);
+      int j = 0;
+      for (String expectedValue : expectedResults.get(i)) {
+        assertEquals(expectedValue, parts[j++]);
       }
     }
   }
@@ -235,20 +215,9 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     HdfsSinkConnectorConfig config = new HdfsSinkConnectorConfig(props);
     DataWriter hdfsWriter = new DataWriter(config, context, avroData);
 
-    String key = "key";
     Schema schema = createSchema();
-
-    Struct[] records = createRecords(schema);
-    ArrayList<SinkRecord> sinkRecords = new ArrayList<>();
-    long offset = 0;
-    for (Struct record : records) {
-      for (long count = 0; count < 3; count++) {
-        SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record,
-                                               offset + count);
-        sinkRecords.add(sinkRecord);
-      }
-      offset = offset + 3;
-    }
+    List<Struct> records = createRecordBatches(schema, 3, 3);
+    List<SinkRecord> sinkRecords = createSinkRecords(records, schema);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close(assignment);
@@ -257,12 +226,12 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
 
     List<String> expectedColumnNames = new ArrayList<>();
-    for (Field field: schema.fields()) {
+    for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
     }
 
     List<String> actualColumnNames = new ArrayList<>();
-    for (FieldSchema column: table.getSd().getCols()) {
+    for (FieldSchema column : table.getSd().getCols()) {
       actualColumnNames.add(column.getName());
     }
     assertEquals(expectedColumnNames, actualColumnNames);
@@ -281,17 +250,23 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
 
     ArrayList<String> partitionFields = new ArrayList<>();
     String[] groups = encodedPartition.split("/");
-    for (String group: groups) {
+    for (String group : groups) {
       String field = group.split("=")[1];
       partitionFields.add(field);
     }
 
-    ArrayList<String[]> expectedResult = new ArrayList<>();
-    for (int i = 16; i <= 18; ++i) {
-      String[] part = {"true", String.valueOf(i), "12", "12.2", "12.2",
-                       partitionFields.get(0), partitionFields.get(1), partitionFields.get(2)};
-      for (int j = 0; j < 3; ++j) {
-        expectedResult.add(part);
+    List<List<String>> expectedResults = new ArrayList<>();
+    for (int j = 0; j < 3; ++j) {
+      for (int i = 0; i < 3; ++i) {
+        List<String> result = Arrays.asList("true",
+                                            String.valueOf(16 + i),
+                                            String.valueOf((long) (16 + i)),
+                                            String.valueOf(12.2f + i),
+                                            String.valueOf((double) (12.2f + i)),
+                                            partitionFields.get(0),
+                                            partitionFields.get(1),
+                                            partitionFields.get(2));
+        expectedResults.add(result);
       }
     }
 
@@ -300,38 +275,11 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     assertEquals(9, rows.length);
     for (int i = 0; i < rows.length; ++i) {
       String[] parts = HiveTestUtils.parseOutput(rows[i]);
-      for (int j = 0; j < expectedResult.get(i).length; ++j) {
-        assertEquals(expectedResult.get(i)[j], parts[j]);
+      int j = 0;
+      for (String expectedValue : expectedResults.get(i)) {
+        System.err.println("Exp: " + expectedValue + " Actual: " + parts[j]);
+        assertEquals(expectedValue, parts[j++]);
       }
     }
-  }
-
-  private Struct[] createRecords(Schema schema) {
-    Struct record1 = new Struct(schema)
-        .put("boolean", true)
-        .put("int", 16)
-        .put("long", 12L)
-        .put("float", 12.2f)
-        .put("double", 12.2);
-
-    Struct record2 = new Struct(schema)
-        .put("boolean", true)
-        .put("int", 17)
-        .put("long", 12L)
-        .put("float", 12.2f)
-        .put("double", 12.2);
-
-    Struct record3 = new Struct(schema)
-        .put("boolean", true)
-        .put("int", 18)
-        .put("long", 12L)
-        .put("float", 12.2f)
-        .put("double", 12.2);
-
-    ArrayList<Struct> records = new ArrayList<>();
-    records.add(record1);
-    records.add(record2);
-    records.add(record3);
-    return records.toArray(new Struct[records.size()]);
   }
 }

--- a/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
@@ -69,9 +69,12 @@ public class ParquetHiveUtilTest extends HiveTestBase {
     String location = "partition=" + String.valueOf(PARTITION);
     hiveMetaStore.addPartition(hiveDatabase, TOPIC, location);
 
+    Struct expectedRecord = createRecord(schema);
+    List<String> expectedResult = new ArrayList<>();
     List<String> expectedColumnNames = new ArrayList<>();
-    for (Field field: schema.fields()) {
+    for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
+      expectedResult.add(String.valueOf(expectedRecord.get(field.name())));
     }
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
@@ -85,15 +88,15 @@ public class ParquetHiveUtilTest extends HiveTestBase {
     assertEquals(1, partitionCols.size());
     assertEquals("partition", partitionCols.get(0).getName());
 
-    String[] expectedResult = {"true", "12", "12", "12.2", "12.2", "12"};
-    String result = HiveTestUtils.runHive(hiveExec, "SELECT * FROM " + TOPIC);
+    String result = HiveTestUtils.runHive(hiveExec, "SELECT * from " + TOPIC);
     String[] rows = result.split("\n");
     // Only 6 of the 7 records should have been delivered due to flush_size = 3
     assertEquals(6, rows.length);
-    for (String row: rows) {
+    for (String row : rows) {
       String[] parts = HiveTestUtils.parseOutput(row);
-      for (int j = 0; j < expectedResult.length; ++j) {
-        assertEquals(expectedResult[j], parts[j]);
+      int j = 0;
+      for (String expectedValue : expectedResult) {
+        assertEquals(expectedValue, parts[j++]);
       }
     }
   }
@@ -108,9 +111,13 @@ public class ParquetHiveUtilTest extends HiveTestBase {
     String location = "partition=" + String.valueOf(PARTITION);
     hiveMetaStore.addPartition(hiveDatabase, TOPIC, location);
 
+    Schema newSchema = createNewSchema();
+    Struct expectedRecord = createRecord(newSchema);
+    List<String> expectedResult = new ArrayList<>();
     List<String> expectedColumnNames = new ArrayList<>();
-    for (Field field: schema.fields()) {
+    for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
+      expectedResult.add(String.valueOf(expectedRecord.get(field.name())));
     }
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
@@ -121,19 +128,17 @@ public class ParquetHiveUtilTest extends HiveTestBase {
 
     assertEquals(expectedColumnNames, actualColumnNames);
 
-    Schema newSchema = createNewSchema();
-
     hive.alterSchema(hiveDatabase, TOPIC, newSchema);
 
-    String[] expectedResult = {"true", "12", "12", "12.2", "12.2", "NULL", "12"};
     String result = HiveTestUtils.runHive(hiveExec, "SELECT * from " + TOPIC);
     String[] rows = result.split("\n");
     // Only 6 of the 7 records should have been delivered due to flush_size = 3
     assertEquals(6, rows.length);
-    for (String row: rows) {
+    for (String row : rows) {
       String[] parts = HiveTestUtils.parseOutput(row);
-      for (int j = 0; j < expectedResult.length; ++j) {
-        assertEquals(expectedResult[j], parts[j]);
+      int j = 0;
+      for (String expectedValue : expectedResult) {
+        assertEquals(expectedValue, parts[j++]);
       }
     }
   }


### PR DESCRIPTION
Added a few test cases. 

But mainly adding necessary refactorings in junit tests in order to be able to write more tests and iterate easier over more records, in anticipation of additional formatters. 