### PR TITLE
Exactly-once should also work with custom partitioner

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -429,7 +429,8 @@ public class TopicPartitionWriter {
 
   private void readOffset() throws ConnectException {
     try {
-      String path = FileUtils.topicDirectory(url, topicsDir, tp.topic());
+      String partitionedPath = partitioner.generatePartitionedPath(tp.topic(), "");
+      String path = FileUtils.topicDirectory(url, topicsDir, partitionedPath);
       CommittedFileFilter filter = new TopicPartitionCommittedFileFilter(tp);
       FileStatus fileStatusWithMaxOffset = FileUtils.fileStatusWithMaxOffset(storage, new Path(path), filter);
       if (fileStatusWithMaxOffset != null) {


### PR DESCRIPTION
Hi all,

We created our custom partitioner that extends `TimeBasedPartitioner` and dumps the data of Kafka topics `prod.a.b` to the following HDFS tree: `/data/prod/a/b/time=event/bucket=hourly/year=XXXX/month=XX/day=XX`.

Everything seemed working fine, but we had to restart the kafka-connect-hdfs connector and we noticed that everything was dumped again from the first earliest offset, even if the records were already dumped. Consequence: exactly-once guaranty was broken.

After some investigations, we discovered that the connector finds the last committed offset of the partition in the name of the files dumped in HDFS. So in theory if we have the following tree, then the last committed offset of partition 8 should be `21652419458` (last file):
```
/data/prod/a/b/time=event/bucket=hourly/year=2017/month=05/day=11/hour=11/prod.a.b+8+21648050968+21648050968.avro
/data/prod/a/b/time=event/bucket=hourly/year=2017/month=05/day=11/hour=11/prod.a.b+8+21648546828+21648760611.avro
/data/prod/a/b/time=event/bucket=hourly/year=2017/month=05/day=11/hour=11/prod.a.b+8+21652419458+21652419458.avro
```

but in our case, the connector was not able to find any file and set the last committed offset to 0. Why?

Finally we found: with our configuration (`topics.dir = /data/` and `topics = prod.a.b`) the connector was searching in `/data/prod.a.b` instead of `/data/prod/a/b/time=event/bucket=hourly/...`

To fix this issue, we propose to also use the partitioner in that case to generate the right path.

Thank you in advance for your feedback