### PR TITLE
Allow cascading Hive updates

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/hive/HiveMetaStore.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/HiveMetaStore.java
@@ -205,11 +205,11 @@ public class HiveMetaStore {
     }
   }
 
-  public void alterTable(final Table table) throws HiveMetaStoreException {
+  public void alterTable(final Table table, final boolean cascade) throws HiveMetaStoreException {
     ClientAction<Void> alter = new ClientAction<Void>() {
       @Override
       public Void call() throws TException {
-        client.alter_table(table.getDbName(), table.getTableName(), table.getTTable());
+        client.alter_table(table.getDbName(), table.getTableName(), table.getTTable(), cascade);
         return null;
       }
     };
@@ -227,6 +227,10 @@ public class HiveMetaStore {
     } catch (TException e) {
       throw new HiveMetaStoreException("Exception communicating with the Hive MetaStore", e);
     }
+  }
+
+  public void alterTable(final Table table) throws HiveMetaStoreException {
+    alterTable(table, false);
   }
 
   public void dropTable(final String database, final String tableName) {

--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtil.java
@@ -51,7 +51,7 @@ public class ParquetHiveUtil extends HiveUtil {
     Table table = hiveMetaStore.getTable(database, tableName);
     List<FieldSchema> columns = HiveSchemaConverter.convertSchema(schema);
     table.setFields(columns);
-    hiveMetaStore.alterTable(table);
+    hiveMetaStore.alterTable(table, true);
   }
 
   private Table constructParquetTable(String database, String tableName, Schema schema, Partitioner partitioner) throws HiveMetaStoreException {

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -79,6 +79,19 @@ public class HdfsSinkConnectorTestBase {
         .put("double", 12.2);
   }
 
+
+  protected Schema createUpdatedSchemaWithFieldsInTheMiddleAndEnd() {
+    return SchemaBuilder.struct().name("record").version(2)
+            .field("boolean", Schema.BOOLEAN_SCHEMA)
+            .field("int", Schema.INT32_SCHEMA)
+            .field("string", Schema.STRING_SCHEMA)
+            .field("long", Schema.INT64_SCHEMA)
+            .field("float", Schema.FLOAT32_SCHEMA)
+            .field("double", Schema.FLOAT64_SCHEMA)
+            .field("string2", Schema.STRING_SCHEMA)
+            .build();
+  }
+
   protected Schema createNewSchema() {
     return SchemaBuilder.struct().name("record").version(2)
         .field("boolean", Schema.BOOLEAN_SCHEMA)


### PR DESCRIPTION
- Allowing for cascading updates to Hive.
- Defaulting Parquet connectors to update schemas using cascading.