### PR TITLE
New parameter to rename partition column

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -406,6 +406,7 @@ public class DataWriter {
     map.put(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG, config.getString(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG));
     map.put(HdfsSinkConnectorConfig.LOCALE_CONFIG, config.getString(HdfsSinkConnectorConfig.LOCALE_CONFIG));
     map.put(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, config.getString(HdfsSinkConnectorConfig.TIMEZONE_CONFIG));
+    map.put(HdfsSinkConnectorConfig.PARTITION_FIELD_NEW_COLUMN_NAME_CONFIG, config.getString(HdfsSinkConnectorConfig.PARTITION_FIELD_NEW_COLUMN_NAME_CONFIG));
     return map;
   }
 }

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -194,6 +194,10 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
   private static final String PARTITION_DURATION_MS_DOC =
       "The duration of a partition milliseconds used by ``TimeBasedPartitioner``. "
       + "The default value -1 means that we are not using ``TimebasedPartitioner``.";
+  public static final String PARTITION_FIELD_NEW_COLUMN_NAME_CONFIG = "partition.field.new.column.name";
+  public static final String PARTITION_FIELD_NEW_COLUMN_NAME_DEFAULT = "";
+  private static final String PARTITION_FIELD_NEW_COLUMN_NAME_DOC = "The name of the partitioned column. Different from the partition field name in case of column name collision";
+  public static final String PARTITION_FIELD_NEW_COLUMN_NAME_DISPLAY = "Column Name for Partition Column";
   public static final long PARTITION_DURATION_MS_DEFAULT = -1L;
   private static final String PARTITION_DURATION_MS_DISPLAY = "Partition Duration (ms)";
 
@@ -305,7 +309,7 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
         .define(RETRY_BACKOFF_CONFIG, Type.LONG, RETRY_BACKOFF_DEFAULT, Importance.LOW, RETRY_BACKOFF_DOC, CONNECTOR_GROUP, 4, Width.SHORT, RETRY_BACKOFF_DISPLAY)
         .define(SHUTDOWN_TIMEOUT_CONFIG, Type.LONG, SHUTDOWN_TIMEOUT_DEFAULT, Importance.MEDIUM, SHUTDOWN_TIMEOUT_DOC, CONNECTOR_GROUP, 5, Width.SHORT, SHUTDOWN_TIMEOUT_DISPLAY)
         .define(PARTITIONER_CLASS_CONFIG, Type.STRING, PARTITIONER_CLASS_DEFAULT, Importance.HIGH, PARTITIONER_CLASS_DOC, CONNECTOR_GROUP, 6, Width.LONG, PARTITIONER_CLASS_DISPLAY,
-                Arrays.asList(PARTITION_FIELD_NAME_CONFIG, PARTITION_DURATION_MS_CONFIG, PATH_FORMAT_CONFIG, LOCALE_CONFIG, TIMEZONE_CONFIG))
+                Arrays.asList(PARTITION_FIELD_NAME_CONFIG, PARTITION_DURATION_MS_CONFIG, PATH_FORMAT_CONFIG, LOCALE_CONFIG, TIMEZONE_CONFIG, PARTITION_FIELD_NEW_COLUMN_NAME_CONFIG))
         .define(PARTITION_FIELD_NAME_CONFIG, Type.STRING, PARTITION_FIELD_NAME_DEFAULT, Importance.MEDIUM, PARTITION_FIELD_NAME_DOC, CONNECTOR_GROUP, 7, Width.MEDIUM,
                 PARTITION_FIELD_NAME_DISPLAY, partitionerClassDependentsRecommender)
         .define(PARTITION_DURATION_MS_CONFIG, Type.LONG, PARTITION_DURATION_MS_DEFAULT, Importance.MEDIUM, PARTITION_DURATION_MS_DOC, CONNECTOR_GROUP, 8, Width.SHORT,
@@ -315,7 +319,9 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
         .define(LOCALE_CONFIG, Type.STRING, LOCALE_DEFAULT, Importance.MEDIUM, LOCALE_DOC, CONNECTOR_GROUP, 10, Width.MEDIUM, LOCALE_DISPLAY, partitionerClassDependentsRecommender)
         .define(TIMEZONE_CONFIG, Type.STRING, TIMEZONE_DEFAULT, Importance.MEDIUM, TIMEZONE_DOC, CONNECTOR_GROUP, 11, Width.MEDIUM, TIMEZONE_DISPLAY, partitionerClassDependentsRecommender)
         .define(FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG, Type.INT, FILENAME_OFFSET_ZERO_PAD_WIDTH_DEFAULT, ConfigDef.Range.atLeast(0), Importance.LOW, FILENAME_OFFSET_ZERO_PAD_WIDTH_DOC,
-                CONNECTOR_GROUP, 12, Width.SHORT, FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY);
+                CONNECTOR_GROUP, 12, Width.SHORT, FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY)
+            .define(PARTITION_FIELD_NEW_COLUMN_NAME_CONFIG, Type.STRING, PARTITION_FIELD_NEW_COLUMN_NAME_DEFAULT, Importance.MEDIUM, PARTITION_FIELD_NEW_COLUMN_NAME_DOC, CONNECTOR_GROUP, 13, Width.MEDIUM,
+                    PARTITION_FIELD_NEW_COLUMN_NAME_DISPLAY, partitionerClassDependentsRecommender);
 
     // Define Internal configuration group
     config.define(STORAGE_CLASS_CONFIG, Type.STRING, STORAGE_CLASS_DEFAULT, Importance.LOW, STORAGE_CLASS_DOC, INTERNAL_GROUP, 1, Width.MEDIUM, STORAGE_CLASS_DISPLAY);

--- a/src/main/java/io/confluent/connect/hdfs/partitioner/FieldPartitioner.java
+++ b/src/main/java/io/confluent/connect/hdfs/partitioner/FieldPartitioner.java
@@ -33,12 +33,18 @@ import io.confluent.connect.hdfs.errors.PartitionException;
 public class FieldPartitioner implements Partitioner {
   private static final Logger log = LoggerFactory.getLogger(FieldPartitioner.class);
   private static String fieldName;
+  private static String partitionColumnName;
   private List<FieldSchema> partitionFields = new ArrayList<>();
 
   @Override
   public void configure(Map<String, Object> config) {
     fieldName = (String) config.get(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG);
-    partitionFields.add(new FieldSchema(fieldName, TypeInfoFactory.stringTypeInfo.toString(), ""));
+    partitionColumnName = (String) config.get(HdfsSinkConnectorConfig.PARTITION_FIELD_NEW_COLUMN_NAME_CONFIG);
+    if (partitionColumnName == null || partitionColumnName.trim().equals("")) {
+      partitionColumnName = fieldName;
+    }
+
+    partitionFields.add(new FieldSchema(partitionColumnName, TypeInfoFactory.stringTypeInfo.toString(), ""));
   }
 
   @Override
@@ -55,12 +61,12 @@ public class FieldPartitioner implements Partitioner {
         case INT32:
         case INT64:
           Number record = (Number) partitionKey;
-          return fieldName + "=" + record.toString();
+          return partitionColumnName + "=" + record.toString();
         case STRING:
-          return fieldName + "=" + (String) partitionKey;
+          return partitionColumnName + "=" + (String) partitionKey;
         case BOOLEAN:
           boolean booleanRecord = (boolean) partitionKey;
-          return fieldName + "=" + Boolean.toString(booleanRecord);
+          return partitionColumnName + "=" + Boolean.toString(booleanRecord);
         default:
           log.error("Type {} is not supported as a partition key.", type.getName());
           throw new PartitionException("Error encoding partition.");


### PR DESCRIPTION
Created a new parameter that allows the connector to rename the partition column in the FieldPartitioner.  We found this helps support Presto since two columns with the same name aren't seen as a valid configuration.