### PR TITLE
Add commons-lang3, kyro and avro-mapred as dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,21 @@
             <version>${confluent.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware.kryo</groupId>
+            <artifactId>kryo</artifactId>
+            <version>2.22</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-mapred</artifactId>
+            <version>1.8.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hadoop.version}</version>


### PR DESCRIPTION
We are removing storage-common's dependency on hive-exec and instead using
hive-exec:core. This means the HDFS connector has to include the missing
libraries itself. Here we are adding commons-lang3, kyro and avro-mapred.

Signed-off-by: Arjun Satish <arjun@confluent.io>