### PR TITLE
modify COMMMITTED_FILENAME_SEPARATOR to under line

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -82,17 +82,18 @@ public class FileUtils {
       long startOffset,
       long endOffset,
       String extension,
-      String zeroPadFormat
+      String zeroPadFormat,
+      String fileDelim
   ) {
     String topic = topicPart.topic();
     int partition = topicPart.partition();
     StringBuilder sb = new StringBuilder();
     sb.append(topic);
-    sb.append(HdfsSinkConnectorConstants.COMMMITTED_FILENAME_SEPARATOR);
+    sb.append(fileDelim);
     sb.append(partition);
-    sb.append(HdfsSinkConnectorConstants.COMMMITTED_FILENAME_SEPARATOR);
+    sb.append(fileDelim);
     sb.append(String.format(zeroPadFormat, startOffset));
-    sb.append(HdfsSinkConnectorConstants.COMMMITTED_FILENAME_SEPARATOR);
+    sb.append(fileDelim);
     sb.append(String.format(zeroPadFormat, endOffset));
     sb.append(extension);
     String name = sb.toString();

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -52,6 +52,11 @@ import static io.confluent.connect.storage.common.StorageCommonConfig.STORAGE_CL
 import static io.confluent.connect.storage.common.StorageCommonConfig.STORAGE_CLASS_DISPLAY;
 import static io.confluent.connect.storage.common.StorageCommonConfig.STORAGE_CLASS_DOC;
 
+import static io.confluent.connect.storage.common.StorageCommonConfig.FILE_DELIM_CONFIG;
+import static io.confluent.connect.storage.common.StorageCommonConfig.FILE_DELIM_DOC;
+import static io.confluent.connect.storage.common.StorageCommonConfig.FILE_DELIM_DISPLAY;
+import static io.confluent.connect.storage.common.StorageCommonConfig.FILE_DELIM_DEFAULT;
+
 public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
 
   // HDFS Group
@@ -122,6 +127,7 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
   private static final GenericRecommender PARTITIONER_CLASS_RECOMMENDER = new GenericRecommender();
   private static final ParentValueRecommender AVRO_COMPRESSION_RECOMMENDER
       = new ParentValueRecommender(FORMAT_CLASS_CONFIG, AvroFormat.class, AVRO_SUPPORTED_CODECS);
+  private static final GenericRecommender FILE_DELIM_RECOMMENDER = new GenericRecommender();
 
   static {
     STORAGE_CLASS_RECOMMENDER.addValidValues(
@@ -385,6 +391,7 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     Set<String> skip = new HashSet<>();
     skip.add(STORAGE_CLASS_CONFIG);
     skip.add(FORMAT_CLASS_CONFIG);
+    skip.add(FILE_DELIM_CONFIG);
 
     // Order added is important, so that group order is maintained
     ConfigDef visible = new ConfigDef();
@@ -418,6 +425,19 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
         Width.NONE,
         FORMAT_CLASS_DISPLAY,
         FORMAT_CLASS_RECOMMENDER
+    );
+
+    visible.define(
+      FILE_DELIM_CONFIG,
+      Type.STRING,
+      FILE_DELIM_DEFAULT,
+      Importance.MEDIUM,
+      FILE_DELIM_DOC,
+      "Storage",
+      1,
+      Width.NONE,
+      FILE_DELIM_DISPLAY,
+      FILE_DELIM_RECOMMENDER
     );
 
     return visible;

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -323,6 +323,7 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     ConcurrentMap<String, String> propsCopy = new ConcurrentHashMap<>(props);
     propsCopy.putIfAbsent(STORAGE_CLASS_CONFIG, HdfsStorage.class.getName());
     propsCopy.putIfAbsent(HdfsSinkConnectorConfig.FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
+    propsCopy.putIfAbsent(FILE_DELIM_CONFIG, FILE_DELIM_DEFAULT);
     return propsCopy;
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConstants.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 
 public class HdfsSinkConnectorConstants {
 
-  public static final String COMMMITTED_FILENAME_SEPARATOR = "+";
+  public static final String COMMMITTED_FILENAME_SEPARATOR = "_";
 
   // groups: topic, partition, start offset, end offset, extension
   // Also see legalChars in Topic.scala

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConstants.java
@@ -18,8 +18,6 @@ import java.util.regex.Pattern;
 
 public class HdfsSinkConnectorConstants {
 
-  public static final String COMMMITTED_FILENAME_SEPARATOR = "_";
-
   // groups: topic, partition, start offset, end offset, extension
   // Also see legalChars in Topic.scala
   public static final Pattern COMMITTED_FILENAME_PATTERN = Pattern.compile(

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -666,6 +666,7 @@ public class TopicPartitionWriter {
     long startOffset = startOffsets.get(encodedPartition);
     long endOffset = offsets.get(encodedPartition);
     String directory = getDirectory(encodedPartition);
+    String fileDelim = connectorConfig.getString(StorageCommonConfig.FILE_DELIM_CONFIG);
     String committedFile = FileUtils.committedFileName(
         url,
         topicsDir,
@@ -674,7 +675,8 @@ public class TopicPartitionWriter {
         startOffset,
         endOffset,
         extension,
-        zeroPadOffsetFormat
+        zeroPadOffsetFormat,
+        fileDelim
     );
     wal.append(tempFile, committedFile);
     appended.add(tempFile);
@@ -715,6 +717,7 @@ public class TopicPartitionWriter {
     long endOffset = offsets.get(encodedPartition);
     String tempFile = tempFiles.get(encodedPartition);
     String directory = getDirectory(encodedPartition);
+    String fileDelim = connectorConfig.getString(StorageCommonConfig.FILE_DELIM_CONFIG);
     String committedFile = FileUtils.committedFileName(
         url,
         topicsDir,
@@ -723,7 +726,8 @@ public class TopicPartitionWriter {
         startOffset,
         endOffset,
         extension,
-        zeroPadOffsetFormat
+        zeroPadOffsetFormat,
+        fileDelim
     );
 
     String directoryName = FileUtils.directoryName(url, topicsDir, directory);

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -60,6 +60,7 @@ public class HdfsSinkConnectorTestBase extends StorageSinkTestBase {
         "io.confluent.connect.hdfs.storage.HdfsStorage"
     );
     props.put(HdfsSinkConnectorConfig.FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
+    props.put(StorageCommonConfig.FILE_DELIM_CONFIG, StorageCommonConfig.FILE_DELIM_DEFAULT);
     props.put(
         PartitionerConfig.PARTITIONER_CLASS_CONFIG,
         DefaultPartitioner.class.getName()

--- a/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
@@ -57,6 +57,7 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
   protected String extension;
   // The default based on default configuration of 10
   protected String zeroPadFormat = "%010d";
+
   private Map<String, String> localProps = new HashMap<>();
 
   @Override

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.hdfs.avro;
 
+import io.confluent.connect.storage.common.StorageCommonConfig;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
@@ -88,13 +89,14 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
 
     wal.append(WAL.beginMarker, "");
 
+    String fileDelim = connectorConfig.getString(StorageCommonConfig.FILE_DELIM_CONFIG);
     for (int i = 0; i < 5; ++i) {
       long startOffset = i * 10;
       long endOffset = (i + 1) * 10 - 1;
       String tempfile = FileUtils.tempFileName(url, topicsDir, getDirectory(), extension);
       fs.createNewFile(new Path(tempfile));
       String committedFile = FileUtils.committedFileName(url, topicsDir, getDirectory(), TOPIC_PARTITION, startOffset,
-                                                         endOffset, extension, zeroPadFormat);
+                                                         endOffset, extension, zeroPadFormat, fileDelim);
       wal.append(tempfile, committedFile);
     }
     wal.append(WAL.endMarker, "");
@@ -176,6 +178,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     String directory = TOPIC + "/" + "partition=" + String.valueOf(PARTITION);
     long[] startOffsets = {0, 3};
     long[] endOffsets = {2, 5};
+    String file
 
     for (int i = 0; i < startOffsets.length; ++i) {
       Path path = new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, startOffsets[i],


### PR DESCRIPTION
If filename in HDFS with plus(+) , it can not be viewed at HUE. For example, if filename is **000010+000020.avro** , then you can not get file from brower caused by not found. The plus will be unquoted to space at backend, so you can not get the file with plus.

<img width="1278" alt="dingtalk20180202104939" src="https://user-images.githubusercontent.com/14155338/35714413-6e892bca-0807-11e8-90dd-0c192ebfb9fb.png">
