### PR TITLE
CC-1669: Set no offset when no offset was found for topic partition

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -618,9 +618,15 @@ public class TopicPartitionWriter {
       // tempfile, but then that tempfile was discarded). To protect against this, even if we
       // just want to start at offset 0 or reset to the earliest offset, we specify that
       // explicitly to forcibly override any committed offsets.
-      long seekOffset = offset > 0 ? offset : 0;
-      log.debug("Resetting offset for {} to {}", tp, seekOffset);
-      context.offset(tp, seekOffset);
+      if (offset > 0) {
+        long seekOffset = offset;
+        log.debug("Resetting offset for {} to {}", tp, seekOffset);
+        context.offset(tp, seekOffset);
+      } else {
+        // The offset was not found, so rather than set the offset to 0 we let the
+        // consumer decide where to start based upon it's `auto.offset.reset` configuration
+        log.debug("Resetting offset for {} based upon consumer's 'auto.offset.reset'", tp);
+      }
       recovered = true;
     }
   }

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -619,13 +619,15 @@ public class TopicPartitionWriter {
       // just want to start at offset 0 or reset to the earliest offset, we specify that
       // explicitly to forcibly override any committed offsets.
       if (offset > 0) {
-        long seekOffset = offset;
-        log.debug("Resetting offset for {} to {}", tp, seekOffset);
-        context.offset(tp, seekOffset);
+        log.debug("Resetting offset for {} to {}", tp, offset);
+        context.offset(tp, offset);
       } else {
-        // The offset was not found, so rather than set the offset to 0 we let the
-        // consumer decide where to start based upon it's `auto.offset.reset` configuration
-        log.debug("Resetting offset for {} based upon consumer's 'auto.offset.reset'", tp);
+        // The offset was not found, so rather than forcibly set the offset to 0 we let the
+        // consumer decide where to start based upon standard consumer offsets (if available)
+        // or the consumer's `auto.offset.reset` configuration
+        log.debug("Resetting offset for {} based upon existing consumer group offsets or, if "
+                  + "there are none, the consumer's 'auto.offset.reset' value.",
+            tp);
       }
       recovered = true;
     }


### PR DESCRIPTION
The HDFS connector always uses an offset of 0 when resetting offsets and there is no output in HDFS for the requested topic partition. This results in the connector _always_ starting at the beginning, regardless of the `consumer.auto.offset.reset` setting.

This commit changes the behavior to not explicitly set an offset when the connector found no output in HDFS for the requested topic partition. As a result, the connector will rely upon the consumer to start where it has been configured, either the beginning if `consumer.auto.offset.reset=earliest` (which is what Connect explicitly sets by default) or at the most recent offset if `consumer.auto.offset.reset=latest` when the worker is explicitly configured this way.

Incidentally, this new behavior matches that of the S3 connector.