### PR TITLE
CC-1700: Revert commits for CC-1669

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -619,15 +619,13 @@ public class TopicPartitionWriter {
       // just want to start at offset 0 or reset to the earliest offset, we specify that
       // explicitly to forcibly override any committed offsets.
       if (offset > 0) {
-        log.debug("Resetting offset for {} to {}", tp, offset);
-        context.offset(tp, offset);
+        long seekOffset = offset;
+        log.debug("Resetting offset for {} to {}", tp, seekOffset);
+        context.offset(tp, seekOffset);
       } else {
-        // The offset was not found, so rather than forcibly set the offset to 0 we let the
-        // consumer decide where to start based upon standard consumer offsets (if available)
-        // or the consumer's `auto.offset.reset` configuration
-        log.debug("Resetting offset for {} based upon existing consumer group offsets or, if "
-                  + "there are none, the consumer's 'auto.offset.reset' value.",
-            tp);
+        // The offset was not found, so rather than set the offset to 0 we let the
+        // consumer decide where to start based upon it's `auto.offset.reset` configuration
+        log.debug("Resetting offset for {} based upon consumer's 'auto.offset.reset'", tp);
       }
       recovered = true;
     }

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -618,15 +618,9 @@ public class TopicPartitionWriter {
       // tempfile, but then that tempfile was discarded). To protect against this, even if we
       // just want to start at offset 0 or reset to the earliest offset, we specify that
       // explicitly to forcibly override any committed offsets.
-      if (offset > 0) {
-        long seekOffset = offset;
-        log.debug("Resetting offset for {} to {}", tp, seekOffset);
-        context.offset(tp, seekOffset);
-      } else {
-        // The offset was not found, so rather than set the offset to 0 we let the
-        // consumer decide where to start based upon it's `auto.offset.reset` configuration
-        log.debug("Resetting offset for {} based upon consumer's 'auto.offset.reset'", tp);
-      }
+      long seekOffset = offset > 0 ? offset : 0;
+      log.debug("Resetting offset for {} to {}", tp, seekOffset);
+      context.offset(tp, seekOffset);
       recovered = true;
     }
   }

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
@@ -74,52 +74,14 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
     task.initialize(context);
     task.start(properties);
 
-    // Without any files in HDFS, we expect no offsets to be set by the connector.
-    // Thus, the consumer will start where it last left off or based upon the
-    // 'auto.offset.reset' setting, which Connect defaults to 'earliest'.
+    // Even without any files in HDFS, we expect an explicit request to start from the beginning of the topic (which
+    // either exists at offset 0, or offset 0 will be out of range and the consumer will reset to the smallest offset).
     Map<TopicPartition, Long> offsets = context.offsets();
-    assertEquals(0, offsets.size());
-
-    task.stop();
-  }
-
-  @Test
-  public void testSinkTaskStartSomeCommittedFiles() throws Exception {
-    setUp();
-
-    Map<TopicPartition, List<String>> tempfiles = new HashMap<>();
-    List<String> list1 = new ArrayList<>();
-    list1.add(FileUtils.tempFileName(url, topicsDir, DIRECTORY1, extension));
-    list1.add(FileUtils.tempFileName(url, topicsDir, DIRECTORY1, extension));
-    tempfiles.put(TOPIC_PARTITION, list1);
-
-    Map<TopicPartition, List<String>> committedFiles = new HashMap<>();
-    List<String> list3 = new ArrayList<>();
-    list3.add(FileUtils.committedFileName(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 100, 200,
-        extension, ZERO_PAD_FMT));
-    list3.add(FileUtils.committedFileName(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 201, 300,
-        extension, ZERO_PAD_FMT));
-    committedFiles.put(TOPIC_PARTITION, list3);
-
-    for (TopicPartition tp : tempfiles.keySet()) {
-      for (String file : tempfiles.get(tp)) {
-        fs.createNewFile(new Path(file));
-      }
-    }
-
-    createWALs(tempfiles, committedFiles);
-    HdfsSinkTask task = new HdfsSinkTask();
-
-    task.initialize(context);
-    task.start(properties);
-
-    // Without any files in HDFS, we expect no offsets to be set by the connector.
-    // Thus, the consumer will start where it last left off or based upon the
-    // 'auto.offset.reset' setting, which Connect defaults to 'earliest'.
-    Map<TopicPartition, Long> offsets = context.offsets();
-    assertEquals(1, offsets.size());
+    assertEquals(offsets.size(), 2);
     assertTrue(offsets.containsKey(TOPIC_PARTITION));
-    assertEquals(301, (long) offsets.get(TOPIC_PARTITION));
+    assertEquals(0, (long) offsets.get(TOPIC_PARTITION));
+    assertTrue(offsets.containsKey(TOPIC_PARTITION2));
+    assertEquals(0, (long) offsets.get(TOPIC_PARTITION2));
 
     task.stop();
   }


### PR DESCRIPTION
This caused a system test to fail. We believe that not explicitly setting the consumer offset in the consumer allows it to pick up some incorrect value from `__consumer_offsets`, and continue processing from there on. This explains the missing data that was observed by the system.

Please find a clean run on Jenkins here: http://confluent-platform-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2018-03-23--002.1521777128--wicknicks--HEAD--7138f66/report.html