### PR TITLE
CC-1669: Disable commit of consumer offsets

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -108,9 +109,16 @@ public class HdfsSinkTask extends SinkTask {
   }
 
   @Override
+  public Map<TopicPartition, OffsetAndMetadata> preCommit(
+      Map<TopicPartition, OffsetAndMetadata> currentOffsets
+  ) {
+    // return an empty map so Connect doesn't commit offsets
+    return Collections.emptyMap();
+  }
+
+  @Override
   public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
-    // clear the offsets here so we don't commit to __consumer_offsets.
-    offsets.clear();
+    // Do nothing as the connector manages the offset
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -93,6 +93,9 @@ public class HdfsSinkTask extends SinkTask {
         hdfsWriter.stop();
       }
     }
+
+    log.info("Consumer offsets will be obtained from filenames on HDFS. This connector will not "
+        + "commit or use any offsets from the __consumer_offsets topic.");
   }
 
   @Override
@@ -106,7 +109,8 @@ public class HdfsSinkTask extends SinkTask {
 
   @Override
   public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
-    // Do nothing as the connector manages the offset
+    // clear the offsets here so we don't commit to __consumer_offsets.
+    offsets.clear();
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -95,8 +95,12 @@ public class HdfsSinkTask extends SinkTask {
       }
     }
 
-    log.info("Consumer offsets will be obtained from filenames on HDFS. This connector will not "
-        + "commit or use any offsets from the __consumer_offsets topic.");
+    log.info("HDFS connector does not commit consumer offsets to Kafka. Upon startup, HDFS "
+        + "Connector restores offsets from filenames in HDFS. In the absence of files in HDFS, "
+        + "the connector will attempt to find offsets for its consumer group in the "
+        + "'__consumer_offsets' topic. If offsets are not found, the consumer will "
+        + "rely on the reset policy specified in the 'consumer.auto.offset.reset' property to "
+        + "start exporting data to HDFS.");
   }
 
   @Override


### PR DESCRIPTION
This change allows the HDFS connector to tell Connect that consumer offsets need not be committed. 

When a new HDFS connector is started, no files are in HDFS for these topic partitions and the connector will then delegate to the consumer as to where to start. Since this PR changes the connector to have no offsets committed to `__consumer_offsets`, there will be no offsets and the consumer will start based upon the `consumer.auto.offset.reset` Connect worker setting (which Connect defaults to `earliest`), per #299.

Note: If any `__consumer_offsets` for the consumer group used by this new connector _are_ found,
 the consumer will use them. This does allow a user to use the Kafka offset reset tool _before_ the connector is start to control exactly where they want the connector to begin.

However, once the HDFS connector writes files to HDFS for each topic partition, then upon startup the connector will always begin at the next offset past the last one written for that topic (via `context.offsets`, causing Connect will seek the connector to that offset).

Signed-off-by: Arjun Satish <arjun@confluent.io>