### PR TITLE
Fix #326 by using config's avroDataConfig method

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -75,10 +75,7 @@ public class HdfsSinkTask extends SinkTask {
         DateTimeZone.forID(timeZoneString);
       }
 
-      int schemaCacheSize = connectorConfig.getInt(
-          HdfsSinkConnectorConfig.SCHEMA_CACHE_SIZE_CONFIG
-      );
-      avroData = new AvroData(schemaCacheSize);
+      avroData = new AvroData(connectorConfig.avroDataConfig());
       hdfsWriter = new DataWriter(connectorConfig, context, avroData);
       recover(assignment);
       if (hiveIntegration) {

--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroFormat.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroFormat.java
@@ -29,9 +29,7 @@ public class AvroFormat
 
   // DO NOT change this signature, it is required for instantiation via reflection
   public AvroFormat(HdfsStorage storage) {
-    this.avroData = new AvroData(
-        storage.conf().getInt(HdfsSinkConnectorConfig.SCHEMA_CACHE_SIZE_CONFIG)
-    );
+    this.avroData = new AvroData(storage.conf().avroDataConfig());
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetFormat.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetFormat.java
@@ -29,9 +29,7 @@ public class ParquetFormat
 
   // DO NOT change this signature, it is required for instantiation via reflection
   public ParquetFormat(HdfsStorage storage) {
-    this.avroData = new AvroData(
-        storage.conf().getInt(HdfsSinkConnectorConfig.SCHEMA_CACHE_SIZE_CONFIG)
-    );
+    this.avroData = new AvroData(storage.conf().avroDataConfig());
   }
 
   @Override

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -116,9 +116,7 @@ public class HdfsSinkConnectorTestBase extends StorageSinkTestBase {
     conf = connectorConfig.getHadoopConfiguration();
     topicsDir = connectorConfig.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
     logsDir = connectorConfig.getString(HdfsSinkConnectorConfig.LOGS_DIR_CONFIG);
-    avroData = new AvroData(
-        connectorConfig.getInt(HdfsSinkConnectorConfig.SCHEMA_CACHE_SIZE_CONFIG)
-    );
+    avroData = new AvroData(connectorConfig.avroDataConfig());
   }
 
   @After


### PR DESCRIPTION
While there's nothing wrong in this change itself, `avroDataConfig` has an issue, reported on confluentinc/kafka-connect-storage-common#64 (pull request with fix has been provided), that makes the resulting `AvroDataConfig` not have the cache size, which is the _only_ configuration provided before this PR.

As long as that is fixed, this preserves the cache information _and_ provides the other settings.