### PR TITLE
MINOR update Jenkinsfile to use JDK8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,5 @@
 common {
   slackChannel = '#connect-eng'
   upstreamProjects = 'confluentinc/schema-registry,confluentinc/kafka-connect-storage-common'
+  nodeLabel = 'docker-oraclejdk8'
 }


### PR DESCRIPTION
Since Hadoop 2.7.x is not compatible with Java 9+,
see https://github.com/elastic/elasticsearch/issues/25450