### PR TITLE
Fixed issue #343

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
@@ -71,7 +71,7 @@ public class AvroRecordWriterProvider
           }
         }
 
-        log.trace("Sink record: {}", record.toString());
+        log.trace("Sink record: {}", record);
         Object value = avroData.fromConnectData(schema, record.value());
         try {
           // AvroData wraps primitive types so their schema can be included. We need to unwrap

--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -95,7 +95,7 @@ public class ParquetRecordWriterProvider
           }
         }
 
-        log.trace("Sink record: {}", record.toString());
+        log.trace("Sink record: {}", record);
         Object value = avroData.fromConnectData(record.valueSchema(), record.value());
         try {
           writer.write((GenericRecord) value);


### PR DESCRIPTION
Small fix preventing the call to toString on each written record in parquet format. The purpose is to enhance performances when logging trace level is disabled.
Issue described in #343 .