### PR TITLE
Use new API from confluentinc/kafka-connect-storage-common#77

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -553,7 +553,7 @@ public class DataWriter {
       partitioner = new PartitionerWrapper(partitionerClass.newInstance());
     }
 
-    partitioner.configure(new HashMap<>(config.plainValues()));
+    partitioner.configure(config.plainValues());
     return partitioner;
   }
 
@@ -567,8 +567,8 @@ public class DataWriter {
     }
 
     @Override
-    public void configure(Map<String, Object> config) {
-      partitioner.configure(config);
+    public void configure(Map<String, String> props) {
+      partitioner.configure(props);
     }
 
     @Override
@@ -596,37 +596,5 @@ public class DataWriter {
       sb.append("/");
     }
     return sb.toString();
-  }
-
-  private Partitioner createPartitioner(HdfsSinkConnectorConfig config)
-      throws ClassNotFoundException, IllegalAccessException, InstantiationException {
-
-    @SuppressWarnings("unchecked")
-    Class<? extends Partitioner> partitionerClasss = (Class<? extends Partitioner>)
-        Class.forName(config.getString(PartitionerConfig.PARTITIONER_CLASS_CONFIG));
-
-    Map<String, Object> map = copyConfig(config);
-    Partitioner partitioner = partitionerClasss.newInstance();
-    partitioner.configure(map);
-    return partitioner;
-  }
-
-  private Map<String, Object> copyConfig(HdfsSinkConnectorConfig config) {
-    Map<String, Object> map = new HashMap<>();
-    map.put(
-        PartitionerConfig.PARTITION_FIELD_NAME_CONFIG,
-        config.getString(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG)
-    );
-    map.put(
-        PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
-        config.getLong(PartitionerConfig.PARTITION_DURATION_MS_CONFIG)
-    );
-    map.put(
-        PartitionerConfig.PATH_FORMAT_CONFIG,
-        config.getString(PartitionerConfig.PATH_FORMAT_CONFIG)
-    );
-    map.put(PartitionerConfig.LOCALE_CONFIG, config.getString(PartitionerConfig.LOCALE_CONFIG));
-    map.put(PartitionerConfig.TIMEZONE_CONFIG, config.getString(PartitionerConfig.TIMEZONE_CONFIG));
-    return map;
   }
 }

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -117,9 +117,9 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
       new BooleanParentRecommender(
           HDFS_AUTHENTICATION_KERBEROS_CONFIG);
 
-  private static final GenericRecommender STORAGE_CLASS_RECOMMENDER = new GenericRecommender();
+  public static final GenericRecommender STORAGE_CLASS_RECOMMENDER = new GenericRecommender();
   private static final GenericRecommender FORMAT_CLASS_RECOMMENDER = new GenericRecommender();
-  private static final GenericRecommender PARTITIONER_CLASS_RECOMMENDER = new GenericRecommender();
+  public static final GenericRecommender PARTITIONER_CLASS_RECOMMENDER = new GenericRecommender();
   private static final ParentValueRecommender AVRO_COMPRESSION_RECOMMENDER
       = new ParentValueRecommender(FORMAT_CLASS_CONFIG, AvroFormat.class, AVRO_SUPPORTED_CODECS);
 
@@ -353,12 +353,8 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     return hadoopConfig;
   }
 
-  public Map<String, ?> plainValues() {
-    Map<String, Object> map = new HashMap<>();
-    for (AbstractConfig config : allConfigs) {
-      map.putAll(config.values());
-    }
-    return map;
+  public Map<String, String> plainValues() {
+    return addDefaults(originalsStrings());
   }
 
   private static class BooleanParentRecommender implements ConfigDef.Recommender {

--- a/src/main/java/io/confluent/connect/hdfs/partitioner/Partitioner.java
+++ b/src/main/java/io/confluent/connect/hdfs/partitioner/Partitioner.java
@@ -15,10 +15,13 @@
 package io.confluent.connect.hdfs.partitioner;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.util.List;
 import java.util.Map;
+
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 
 /**
  * Partition incoming records, and generates directories and file names in which to store the
@@ -28,7 +31,17 @@ import java.util.Map;
 public interface Partitioner
     extends io.confluent.connect.storage.partitioner.Partitioner<FieldSchema> {
   @Override
-  void configure(Map<String, Object> config);
+  default ConfigDef.Recommender getPartitionerRecommender() {
+    return HdfsSinkConnectorConfig.PARTITIONER_CLASS_RECOMMENDER;
+  }
+
+  @Override
+  default ConfigDef.Recommender getStorageRecommender() {
+    return HdfsSinkConnectorConfig.STORAGE_CLASS_RECOMMENDER;
+  }
+
+  @Override
+  void configure(Map<String, String> config);
 
   @Override
   String encodePartition(SinkRecord sinkRecord);

--- a/src/test/java/io/confluent/connect/hdfs/FormatAPITopicPartitionWriterCompatibilityTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FormatAPITopicPartitionWriterCompatibilityTest.java
@@ -62,7 +62,7 @@ public class FormatAPITopicPartitionWriterCompatibilityTest extends TestWithMini
   @Test
   public void testWriteRecordDefaultWithPadding() throws Exception {
     Partitioner partitioner = new DefaultPartitioner();
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
         TOPIC_PARTITION,
         storage,

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
@@ -206,7 +206,7 @@ public class HdfsSinkConnectorConfigTest extends TestWithMiniDFSCluster {
 
     Partitioner<?> klass = new Partitioner<FieldSchema>() {
       @Override
-      public void configure(Map<String, Object> config) {}
+      public void configure(Map<String, String> config) {}
 
       @Override
       public String encodePartition(SinkRecord sinkRecord) {
@@ -336,7 +336,7 @@ public class HdfsSinkConnectorConfigTest extends TestWithMiniDFSCluster {
     io.confluent.connect.hdfs.partitioner.Partitioner klass =
         new io.confluent.connect.hdfs.partitioner.Partitioner() {
       @Override
-      public void configure(Map<String, Object> config) {}
+      public void configure(Map<String, String> config) {}
 
       @Override
       public String encodePartition(SinkRecord sinkRecord) {

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -23,7 +23,6 @@ import org.apache.kafka.connect.data.Struct;
 import org.junit.After;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -33,13 +32,12 @@ import io.confluent.connect.hdfs.avro.AvroFormat;
 import io.confluent.connect.hdfs.partitioner.DefaultPartitioner;
 import io.confluent.connect.storage.StorageSinkTestBase;
 import io.confluent.connect.storage.common.StorageCommonConfig;
-import io.confluent.connect.storage.hive.schema.DefaultSchemaGenerator;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
 public class HdfsSinkConnectorTestBase extends StorageSinkTestBase {
 
   protected HdfsSinkConnectorConfig connectorConfig;
-  protected Map<String, Object> parsedConfig;
+  protected Map<String, String> propsWithDefaults;
   protected Configuration conf;
   protected String topicsDir;
   protected String logsDir;
@@ -112,7 +110,7 @@ public class HdfsSinkConnectorTestBase extends StorageSinkTestBase {
   public void setUp() throws Exception {
     super.setUp();
     connectorConfig = new HdfsSinkConnectorConfig(properties);
-    parsedConfig = new HashMap<>(connectorConfig.plainValues());
+    propsWithDefaults = connectorConfig.plainValues();
     conf = connectorConfig.getHadoopConfiguration();
     topicsDir = connectorConfig.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
     logsDir = connectorConfig.getString(HdfsSinkConnectorConfig.LOGS_DIR_CONFIG);

--- a/src/test/java/io/confluent/connect/hdfs/avro/AvroHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/AvroHiveUtilTest.java
@@ -59,7 +59,7 @@ public class AvroHiveUtilTest extends HiveTestBase {
   public void testCreateTable() throws Exception {
     setUp();
     prepareData(TOPIC, PARTITION);
-    Partitioner partitioner = HiveTestUtils.getPartitioner(parsedConfig);
+    Partitioner partitioner = HiveTestUtils.getPartitioner(propsWithDefaults);
 
     Schema schema = createSchema();
     hive.createTable(hiveDatabase, TOPIC, schema, partitioner);
@@ -105,7 +105,7 @@ public class AvroHiveUtilTest extends HiveTestBase {
   public void testAlterSchema() throws Exception {
     setUp();
     prepareData(TOPIC, PARTITION);
-    Partitioner partitioner = HiveTestUtils.getPartitioner(parsedConfig);
+    Partitioner partitioner = HiveTestUtils.getPartitioner(propsWithDefaults);
     Schema schema = createSchema();
     hive.createTable(hiveDatabase, TOPIC, schema, partitioner);
 

--- a/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
@@ -58,8 +58,9 @@ import io.confluent.connect.storage.partitioner.HourlyPartitioner;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
 import static org.apache.kafka.common.utils.Time.SYSTEM;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
   private RecordWriterProvider writerProvider = null;
@@ -111,7 +112,7 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     localProps.put(HdfsSinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG, "2");
     setUp();
     Partitioner partitioner = new DefaultPartitioner();
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
         TOPIC_PARTITION,
         storage,
@@ -153,10 +154,10 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
   public void testWriteRecordFieldPartitioner() throws Exception {
     setUp();
     Partitioner partitioner = new FieldPartitioner();
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
 
     @SuppressWarnings("unchecked")
-    List<String> partitionFields = (List<String>) parsedConfig.get(
+    List<String> partitionFields = connectorConfig.getList(
         PartitionerConfig.PARTITION_FIELD_NAME_CONFIG
     );
     String partitionField = partitionFields.get(0);
@@ -210,7 +211,7 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
   public void testWriteRecordTimeBasedPartition() throws Exception {
     setUp();
     Partitioner partitioner = new TimeBasedPartitioner();
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
         TOPIC_PARTITION,
@@ -238,11 +239,11 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     topicPartitionWriter.write();
     topicPartitionWriter.close();
 
-    long partitionDurationMs = (Long) parsedConfig.get(
+    long partitionDurationMs = connectorConfig.getLong(
         PartitionerConfig.PARTITION_DURATION_MS_CONFIG
     );
-    String pathFormat = (String) parsedConfig.get(PartitionerConfig.PATH_FORMAT_CONFIG);
-    String timeZoneString = (String) parsedConfig.get(PartitionerConfig.TIMEZONE_CONFIG);
+    String pathFormat = connectorConfig.getString(PartitionerConfig.PATH_FORMAT_CONFIG);
+    String timeZoneString = connectorConfig.getString(PartitionerConfig.TIMEZONE_CONFIG);
     long timestamp = System.currentTimeMillis();
 
     String encodedPartition = TimeUtils.encodeTimestamp(partitionDurationMs, pathFormat, timeZoneString, timestamp);
@@ -266,12 +267,12 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
         HdfsSinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.MINUTES.toMillis(1))
     );
+    localProps.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "RecordField");
     setUp();
 
     // Define the partitioner
     partitioner = new DataWriter.PartitionerWrapper(new HourlyPartitioner<FieldSchema>());
-    parsedConfig.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "RecordField");
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
         TOPIC_PARTITION,
@@ -354,12 +355,12 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
         HdfsSinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.MINUTES.toMillis(1))
     );
+    localProps.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record");
     setUp();
 
     // Define the partitioner
     partitioner = new DataWriter.PartitionerWrapper(new HourlyPartitioner<FieldSchema>());
-    parsedConfig.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record");
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
         TOPIC_PARTITION,
@@ -416,13 +417,14 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
         HdfsSinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.MINUTES.toMillis(1))
     );
+    localProps.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record");
+    localProps.put(PartitionerConfig.PATH_FORMAT_CONFIG,
+        "'year'=YYYY/'month'=MM/'day'=dd");
     setUp();
 
     // Define the partitioner
     partitioner = new DataWriter.PartitionerWrapper(new DailyPartitioner<FieldSchema>());
-    parsedConfig.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record");
-    parsedConfig.put(PartitionerConfig.PATH_FORMAT_CONFIG, "'year'=YYYY/'month'=MM/'day'=dd");
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
         TOPIC_PARTITION,
@@ -484,15 +486,17 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
         HdfsSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.MINUTES.toMillis(10))
     );
+    localProps.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
+        String.valueOf(TimeUnit.DAYS.toMillis(1)));
+    localProps.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
+        MockedWallclockTimestampExtractor.class.getName());
     setUp();
 
     // Define the partitioner
     partitioner = new DataWriter.PartitionerWrapper(
         new io.confluent.connect.storage.partitioner.TimeBasedPartitioner<FieldSchema>()
     );
-    parsedConfig.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.DAYS.toMillis(1));
-    parsedConfig.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockedWallclockTimestampExtractor.class.getName());
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
 
     MockedWallclockTimestampExtractor.TIME.sleep(SYSTEM.milliseconds());
 
@@ -567,9 +571,9 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
   }
 
   private String getTimebasedEncodedPartition(long timestamp) {
-    long partitionDurationMs = (Long) parsedConfig.get(PartitionerConfig.PARTITION_DURATION_MS_CONFIG);
-    String pathFormat = (String) parsedConfig.get(PartitionerConfig.PATH_FORMAT_CONFIG);
-    String timeZone = (String) parsedConfig.get(PartitionerConfig.TIMEZONE_CONFIG);
+    long partitionDurationMs = connectorConfig.getLong(PartitionerConfig.PARTITION_DURATION_MS_CONFIG);
+    String pathFormat = connectorConfig.getString(PartitionerConfig.PATH_FORMAT_CONFIG);
+    String timeZone = connectorConfig.getString(PartitionerConfig.TIMEZONE_CONFIG);
     return TimeUtils.encodeTimestamp(partitionDurationMs, pathFormat, timeZone, timestamp);
   }
 
@@ -594,7 +598,7 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     int index = 0;
     for (FileStatus status : statuses) {
       Path filePath = status.getPath();
-      assertTrue(expectedFiles.contains(status.getPath()));
+      assertThat(expectedFiles, hasItem(status.getPath()));
       Collection<Object> avroRecords = dataFileReader.readData(connectorConfig.getHadoopConfiguration(), filePath);
       assertEquals(expectedSize, avroRecords.size());
       for (Object avroRecord : avroRecords) {
@@ -609,7 +613,7 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     public static final MockTime TIME = new MockTime();
 
     @Override
-    public void configure(Map<String, Object> config) {}
+    public void configure(Map<String, String> config) {}
 
     @Override
     public Long extract(ConnectRecord<?> record) {

--- a/src/test/java/io/confluent/connect/hdfs/hive/HiveTestUtils.java
+++ b/src/test/java/io/confluent/connect/hdfs/hive/HiveTestUtils.java
@@ -28,9 +28,9 @@ import io.confluent.connect.hdfs.partitioner.Partitioner;
 
 public class HiveTestUtils {
 
-  public static Partitioner getPartitioner(Map<String, Object> parsedConfig) {
+  public static Partitioner getPartitioner(Map<String, String> props) {
     Partitioner partitioner = new DefaultPartitioner();
-    partitioner.configure(parsedConfig);
+    partitioner.configure(props);
     return partitioner;
   }
 

--- a/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -63,7 +62,7 @@ public class ParquetHiveUtilTest extends HiveTestBase {
   public void testCreateTable() throws Exception {
     setUp();
     prepareData(TOPIC, PARTITION);
-    Partitioner partitioner = HiveTestUtils.getPartitioner(parsedConfig);
+    Partitioner partitioner = HiveTestUtils.getPartitioner(propsWithDefaults);
 
     Schema schema = createSchema();
     hive.createTable(hiveDatabase, TOPIC, schema, partitioner);
@@ -109,7 +108,7 @@ public class ParquetHiveUtilTest extends HiveTestBase {
   public void testAlterSchema() throws Exception {
     setUp();
     prepareData(TOPIC, PARTITION);
-    Partitioner partitioner = HiveTestUtils.getPartitioner(parsedConfig);
+    Partitioner partitioner = HiveTestUtils.getPartitioner(propsWithDefaults);
     Schema schema = createSchema();
     hive.createTable(hiveDatabase, TOPIC, schema, partitioner);
 

--- a/src/test/java/io/confluent/connect/hdfs/partitioner/DailyPartitionerTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/partitioner/DailyPartitionerTest.java
@@ -18,13 +18,9 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
-import io.confluent.connect.storage.hive.schema.TimeBasedSchemaGenerator;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
 import static org.junit.Assert.assertEquals;
@@ -36,10 +32,10 @@ public class DailyPartitionerTest extends TestWithMiniDFSCluster {
   public void testDailyPartitioner() throws Exception {
     setUp();
     DailyPartitioner partitioner = new DailyPartitioner();
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
 
     String pathFormat = partitioner.getPathFormat();
-    String timeZoneString = (String) parsedConfig.get(PartitionerConfig.TIMEZONE_CONFIG);
+    String timeZoneString = connectorConfig.getString(PartitionerConfig.TIMEZONE_CONFIG);
     long timestamp = new DateTime(2014, 2, 1, 3, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
     String encodedPartition = TimeUtils.encodeTimestamp(partitionDurationMs, pathFormat, timeZoneString, timestamp);
     String path = partitioner.generatePartitionedPath("topic", encodedPartition);

--- a/src/test/java/io/confluent/connect/hdfs/partitioner/HourlyPartitionerTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/partitioner/HourlyPartitionerTest.java
@@ -18,13 +18,9 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
-import io.confluent.connect.storage.hive.schema.TimeBasedSchemaGenerator;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
 import static org.junit.Assert.assertEquals;
@@ -36,10 +32,10 @@ public class HourlyPartitionerTest extends TestWithMiniDFSCluster {
   public void testHourlyPartitioner() throws Exception {
     setUp();
     HourlyPartitioner partitioner = new HourlyPartitioner();
-    partitioner.configure(parsedConfig);
+    partitioner.configure(propsWithDefaults);
 
     String pathFormat = partitioner.getPathFormat();
-    String timeZoneString = (String) parsedConfig.get(PartitionerConfig.TIMEZONE_CONFIG);
+    String timeZoneString = connectorConfig.getString(PartitionerConfig.TIMEZONE_CONFIG);
     long timestamp = new DateTime(2015, 2, 1, 3, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
     String encodedPartition = TimeUtils.encodeTimestamp(partitionDurationMs, pathFormat,
                                                         timeZoneString, timestamp);


### PR DESCRIPTION
The API change itself is trivial to adopt. Get the original values, add
the defaults, and that's done.

However, many tests either relied on implementation details of the
partitioners, or ignored the mechanism used in the very same tests to
pass settings in a reliable way and, instead, modified the configuration
right before it was passed to the partitioner, which made it unavailable
elsewhere as code migrated to relying on HdfsSinkConnectorConfig instead
of the no-longer present parsed config map.