### PR TITLE
CC-274: Recover cleanly with empty WAL file

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.ChecksumException;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.Syncable;
@@ -36,6 +37,7 @@ import org.apache.hadoop.io.serializer.SerializationFactory;
 import org.apache.hadoop.io.serializer.Serializer;
 import org.apache.hadoop.util.Options;
 import org.apache.hadoop.util.Time;
+import org.apache.kafka.connect.errors.ConnectException;
 
 import java.io.Closeable;
 import java.io.DataInputStream;
@@ -208,8 +210,11 @@ public class WALFile {
         long blockSize = blockSizeOption == null ? fs.getDefaultBlockSize(p) :
                          blockSizeOption.getValue();
 
-        if (appendIfExistsOption != null && appendIfExistsOption.getValue()
-            && fs.exists(p)) {
+        if (appendIfExistsOption != null
+            && appendIfExistsOption.getValue()
+            && fs.exists(p)
+            && hasIntactVersionHeader(p, fs)
+        ) {
           // Read the file and verify header details
           try (WALFile.Reader reader =
                    new WALFile.Reader(conf, WALFile.Reader.file(p), new Reader.OnlyHeaderOption())){
@@ -228,6 +233,14 @@ public class WALFile {
       }
 
       init(conf, out, ownStream);
+    }
+    
+    private boolean hasIntactVersionHeader(Path p, FileSystem fs) throws IOException {
+      FileStatus[] statuses = fs.listStatus(p);
+      if (statuses.length != 1) {
+        throw new ConnectException("Expected exactly one log for WAL file " + p);
+      }
+      return statuses[0].getLen() >= VERSION.length;
     }
 
     void init(Configuration conf, FSDataOutputStream out, boolean ownStream)

--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -240,7 +240,11 @@ public class WALFile {
       if (statuses.length != 1) {
         throw new ConnectException("Expected exactly one log for WAL file " + p);
       }
-      return statuses[0].getLen() >= VERSION.length;
+      boolean result = statuses[0].getLen() >= VERSION.length;
+      if (!result) {
+        log.warn("Failed to read version header from WAL file " + p);
+      }
+      return result;
     }
 
     void init(Configuration conf, FSDataOutputStream out, boolean ownStream)


### PR DESCRIPTION
Addresses #53
[JIRA](https://confluentinc.atlassian.net/browse/CC-274)

If the connector is killed in between creating a new log file and writing a version header to that file, it then ends up in an endless loop during the recover process where it continually tries and fails to read a version header from that file.

This fix involves performing a rudimentary check to see if the WAL file contains an empty/incomplete version header, and if so, creating a new WAL file and overwriting the existing one.