### PR TITLE
CC-2493: Improved initialization and logging of Parquet writer

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -80,8 +80,11 @@ public class ParquetRecordWriterProvider
             );
             log.debug("Opened record writer for: {}", filename);
           } catch (IOException e) {
-            log.debug(
-                "Error creating AvroParquetWriter for file '{}', {}, and schema {}: ",
+            // Ultimately caught and logged in TopicPartitionWriter,
+            // but log in debug to provide more context
+            log.warn(
+                "Error creating {} for file '{}', {}, and schema {}: ",
+                AvroParquetWriter.class.getSimpleName(),
                 filename,
                 compressionCodecName,
                 schema,

--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -62,6 +62,10 @@ public class ParquetRecordWriterProvider
       public void write(SinkRecord record) {
         if (schema == null) {
           schema = record.valueSchema();
+          // may still be null at this point
+        }
+
+        if (writer == null) {
           try {
             log.info("Opening record writer for: {}", filename);
             org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
@@ -74,7 +78,15 @@ public class ParquetRecordWriterProvider
                 true,
                 conf.getHadoopConfiguration()
             );
+            log.debug("Opened record writer for: {}", filename);
           } catch (IOException e) {
+            log.debug(
+                "Error creating AvroParquetWriter for file '{}', {}, and schema {}: ",
+                filename,
+                compressionCodecName,
+                schema,
+                e
+            );
             throw new ConnectException(e);
           }
         }


### PR DESCRIPTION
Prior to this change, it was possible that the creation of one Parquet writer failed, and because the HDFS connector’s `TopicPartitionWriter` attempts to retry the call, subsequent calls result in a NPE. This commit always attempts to create the `AvroParquetWriter` when needed (even on subsequent retries), and adds more logging statements to help diagnose the behavior.