### PR TITLE
CC-2399: Fix NPE during close

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -118,8 +118,6 @@ public class HdfsSinkTask extends SinkTask {
   public void close(Collection<TopicPartition> partitions) {
     if (hdfsWriter != null) {
       hdfsWriter.close();
-    } else {
-      log.warn("Close called on a null HDFS writer.");
     }
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -116,7 +116,9 @@ public class HdfsSinkTask extends SinkTask {
 
   @Override
   public void close(Collection<TopicPartition> partitions) {
-    hdfsWriter.close();
+    if (hdfsWriter != null) {
+      hdfsWriter.close();
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -118,6 +118,8 @@ public class HdfsSinkTask extends SinkTask {
   public void close(Collection<TopicPartition> partitions) {
     if (hdfsWriter != null) {
       hdfsWriter.close();
+    } else {
+      log.warn("Close called on a null HDFS writer.");
     }
   }
 


### PR DESCRIPTION
This is to fix NPE from system test:

```
2018-07-19 07:49:57,466 ERROR WorkerSinkTask{id=hdfs-sink-0}
Task threw an uncaught and unrecoverable exception (org.apache.kafka.connect.runtime.WorkerTask)
java.lang.NullPointerException
at io.confluent.connect.hdfs.HdfsSinkTask.close(HdfsSinkTask.java:135)
at org.apache.kafka.connect.runtime.WorkerSinkTask.commitOffsets(WorkerSinkTask.java:376)
at org.apache.kafka.connect.runtime.WorkerSinkTask.closePartitions(WorkerSinkTask.java:560)
at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:183)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:170)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:214)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
at java.util.concurrent.FutureTask.run(FutureTask.java:262)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
at java.lang.Thread.run(Thread.java:745)
```