### PR TITLE
CC-2515: Open temp Parquet files with OVERWRITE mode

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -71,14 +71,14 @@ public class ParquetRecordWriterProvider
             log.info("Opening record writer for: {}", filename);
             org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
             writer = AvroParquetWriter.<GenericRecord>builder(path)
-                                      .withSchema(avroSchema)
-                                      .withCompressionCodec(compressionCodecName)
-                                      .withRowGroupSize(blockSize)
-                                      .withPageSize(pageSize)
-                                      .withDictionaryEncoding(true)
-                                      .withConf(conf.getHadoopConfiguration())
-                                      .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
-                                      .build();
+                .withSchema(avroSchema)
+                .withCompressionCodec(compressionCodecName)
+                .withRowGroupSize(blockSize)
+                .withPageSize(pageSize)
+                .withDictionaryEncoding(true)
+                .withConf(conf.getHadoopConfiguration())
+                .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+                .build();
             log.debug("Opened record writer for: {}", filename);
           } catch (IOException e) {
             // Ultimately caught and logged in TopicPartitionWriter,


### PR DESCRIPTION
Change the `ParquetRecordWriterProvider` class to open the `AvroParquetWriter` instance for each Parquet temp file with ‘overwrite’ mode. This required using the `AvroParquetWriter.Builder` class rather than the deprecated constructor, which did not have a way to specify the mode.

The Avro format's writer already uses an "overwrite" mode, so this brings the same behavior to the Parquet format.

Note that the connector "commits" the records written to a temp file by closing it and moving it to the final location, as part of the HDFS connector's write ahead log behavior. The change in this PR is useful when the connector restarts and there's already an existing Parquet temp file; without this change a `FileAlreadyExistsException` is thrown.

