### PR TITLE
Skip config setting for append-late-data

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -379,6 +379,7 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     Set<String> skip = new HashSet<>();
     skip.add(STORAGE_CLASS_CONFIG);
     skip.add(FORMAT_CLASS_CONFIG);
+    skip.add(APPEND_LATE_DATA);
 
     // Order added is important, so that group order is maintained
     ConfigDef visible = new ConfigDef();


### PR DESCRIPTION
S3 and GCS support this feature, but HDFS does not yet