### PR TITLE
Support for multiple schema types on a single topic

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -14,6 +14,24 @@
 
 package io.confluent.connect.hdfs;
 
+import io.confluent.common.utils.SystemTime;
+import io.confluent.common.utils.Time;
+import io.confluent.connect.avro.AvroData;
+import io.confluent.connect.hdfs.hive.HiveMetaStore;
+import io.confluent.connect.hdfs.hive.HiveServiceProvider;
+import io.confluent.connect.hdfs.hive.HiveTableNamingParameters;
+import io.confluent.connect.hdfs.hive.HiveTableNamingStrategy;
+import io.confluent.connect.hdfs.hive.HiveUtil;
+import io.confluent.connect.hdfs.hive.SchemaNameHiveTableNamingStrategy;
+import io.confluent.connect.hdfs.partitioner.Partitioner;
+import io.confluent.connect.hdfs.schema.SchemaResolutionStrategyProvider;
+import io.confluent.connect.hdfs.schema.SchemaResolutionStrategy;
+import io.confluent.connect.hdfs.storage.HdfsStorage;
+import io.confluent.connect.hdfs.storage.Storage;
+import io.confluent.connect.storage.common.StorageCommonConfig;
+import io.confluent.connect.storage.format.SchemaFileReader;
+import io.confluent.connect.storage.hive.HiveConfig;
+import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -32,13 +50,16 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -47,20 +68,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import io.confluent.common.utils.SystemTime;
-import io.confluent.common.utils.Time;
-import io.confluent.connect.avro.AvroData;
-import io.confluent.connect.hdfs.filter.CommittedFileFilter;
-import io.confluent.connect.hdfs.filter.TopicCommittedFileFilter;
-import io.confluent.connect.hdfs.hive.HiveMetaStore;
-import io.confluent.connect.hdfs.hive.HiveUtil;
-import io.confluent.connect.hdfs.partitioner.Partitioner;
-import io.confluent.connect.hdfs.storage.HdfsStorage;
-import io.confluent.connect.hdfs.storage.Storage;
-import io.confluent.connect.storage.common.StorageCommonConfig;
-import io.confluent.connect.storage.format.SchemaFileReader;
-import io.confluent.connect.storage.hive.HiveConfig;
-import io.confluent.connect.storage.partitioner.PartitionerConfig;
+import static io.confluent.connect.hdfs.FileUtils.topicDirectory;
+import static io.confluent.connect.hdfs.HdfsSinkConnectorConfig.MULTI_SCHEMA_SUPPORT_CONFIG;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 
 public class DataWriter {
   private static final Logger log = LoggerFactory.getLogger(DataWriter.class);
@@ -72,26 +83,24 @@ public class DataWriter {
   private HdfsStorage storage;
   private String topicsDir;
   private Format format;
-  private RecordWriterProvider writerProvider;
-  private io.confluent.connect.storage.format.RecordWriterProvider<HdfsSinkConnectorConfig>
-      newWriterProvider;
-  private io.confluent.connect.storage.format.SchemaFileReader<HdfsSinkConnectorConfig, Path>
-      schemaFileReader;
+  private SchemaResolutionStrategyProvider schemaResolutionStrategyProvider;
   private io.confluent.connect.storage.format.Format<HdfsSinkConnectorConfig, Path> newFormat;
   private Set<TopicPartition> assignment;
   private Partitioner partitioner;
   private Map<TopicPartition, Long> offsets;
   private HdfsSinkConnectorConfig connectorConfig;
-  private AvroData avroData;
   private SinkTaskContext context;
   private ExecutorService executorService;
   private String hiveDatabase;
   private HiveMetaStore hiveMetaStore;
   private HiveUtil hive;
   private Queue<Future<Void>> hiveUpdateFutures;
+  private HiveTableNamingStrategy hiveTableNamingStrategy;
   private boolean hiveIntegration;
   private Thread ticketRenewThread;
   private volatile boolean isRunning;
+  private HiveServiceProvider hiveServiceProvider;
+  private SelectableRecordWriterProvider recoerdWriterProvider;
 
   public DataWriter(
       HdfsSinkConnectorConfig connectorConfig,
@@ -115,7 +124,6 @@ public class DataWriter {
       System.setProperty("hadoop.home.dir", hadoopHome);
 
       this.connectorConfig = connectorConfig;
-      this.avroData = avroData;
       this.context = context;
 
       String hadoopConfDir = connectorConfig.getString(
@@ -222,59 +230,7 @@ public class DataWriter {
       createDir(topicsDir + HdfsSinkConnectorConstants.TEMPFILE_DIRECTORY);
       String logsDir = connectorConfig.getString(HdfsSinkConnectorConfig.LOGS_DIR_CONFIG);
       createDir(logsDir);
-
-      // Try to instantiate as a new-style storage-common type class, then fall back to old-style
-      // with no parameters
-      try {
-        Class<io.confluent.connect.storage.format.Format> formatClass =
-            (Class<io.confluent.connect.storage.format.Format>)
-                connectorConfig.getClass(HdfsSinkConnectorConfig.FORMAT_CLASS_CONFIG);
-        newFormat = formatClass.getConstructor(HdfsStorage.class).newInstance(storage);
-        newWriterProvider = newFormat.getRecordWriterProvider();
-        schemaFileReader = newFormat.getSchemaFileReader();
-      } catch (NoSuchMethodException e) {
-        Class<Format> formatClass =
-            (Class<Format>) connectorConfig.getClass(HdfsSinkConnectorConfig.FORMAT_CLASS_CONFIG);
-        format = formatClass.getConstructor().newInstance();
-        writerProvider = format.getRecordWriterProvider();
-        final io.confluent.connect.hdfs.SchemaFileReader oldReader
-            = format.getSchemaFileReader(avroData);
-        schemaFileReader = new SchemaFileReader<HdfsSinkConnectorConfig, Path>() {
-          @Override
-          public Schema getSchema(HdfsSinkConnectorConfig hdfsSinkConnectorConfig, Path path) {
-            try {
-              return oldReader.getSchema(hdfsSinkConnectorConfig.getHadoopConfiguration(), path);
-            } catch (IOException e) {
-              throw new ConnectException("Failed to get schema", e);
-            }
-          }
-
-          @Override
-          public Iterator<Object> iterator() {
-            throw new UnsupportedOperationException();
-          }
-
-          @Override
-          public boolean hasNext() {
-            throw new UnsupportedOperationException();
-          }
-
-          @Override
-          public Object next() {
-            throw new UnsupportedOperationException();
-          }
-
-          @Override
-          public void remove() {
-            throw new UnsupportedOperationException();
-          }
-
-          @Override
-          public void close() throws IOException {
-
-          }
-        };
-      }
+      setupStorageFormat(connectorConfig, avroData);
 
       partitioner = newPartitioner(connectorConfig);
 
@@ -283,32 +239,7 @@ public class DataWriter {
 
       hiveIntegration = connectorConfig.getBoolean(HiveConfig.HIVE_INTEGRATION_CONFIG);
       if (hiveIntegration) {
-        hiveDatabase = connectorConfig.getString(HiveConfig.HIVE_DATABASE_CONFIG);
-        hiveMetaStore = new HiveMetaStore(conf, connectorConfig);
-        if (format != null) {
-          hive = format.getHiveUtil(connectorConfig, hiveMetaStore);
-        } else if (newFormat != null) {
-          final io.confluent.connect.storage.hive.HiveUtil newHiveUtil
-              = newFormat.getHiveFactory().createHiveUtil(connectorConfig, hiveMetaStore);
-          hive = new HiveUtil(connectorConfig, hiveMetaStore) {
-            @Override
-            public void createTable(
-                String database, String tableName, Schema schema,
-                Partitioner partitioner
-            ) {
-              newHiveUtil.createTable(database, tableName, schema, partitioner);
-            }
-
-            @Override
-            public void alterSchema(String database, String tableName, Schema schema) {
-              newHiveUtil.alterSchema(database, tableName, schema);
-            }
-          };
-        } else {
-          throw new ConnectException("One of old or new format classes must be provided");
-        }
-        executorService = Executors.newSingleThreadExecutor();
-        hiveUpdateFutures = new LinkedList<>();
+        setupHiveIntegration(connectorConfig, conf);
       }
 
       topicPartitionWriters = new HashMap<>();
@@ -316,17 +247,12 @@ public class DataWriter {
         TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
             tp,
             storage,
-            writerProvider,
-            newWriterProvider,
+            recoerdWriterProvider,
             partitioner,
             connectorConfig,
             context,
-            avroData,
-            hiveMetaStore,
-            hive,
-            schemaFileReader,
-            executorService,
-            hiveUpdateFutures,
+            schemaResolutionStrategyProvider.get(tp),
+            hiveServiceProvider != null ? hiveServiceProvider.get(tp) : null,
             time
         );
         topicPartitionWriters.put(tp, topicPartitionWriter);
@@ -341,6 +267,108 @@ public class DataWriter {
     } catch (IOException e) {
       throw new ConnectException(e);
     }
+  }
+
+  private void setupHiveIntegration(HdfsSinkConnectorConfig connectorConfig, Configuration conf) {
+    hiveDatabase = connectorConfig.getString(HiveConfig.HIVE_DATABASE_CONFIG);
+    hiveMetaStore = new HiveMetaStore(conf, connectorConfig);
+    if (format != null) {
+      hive = format.getHiveUtil(connectorConfig, hiveMetaStore);
+    } else if (newFormat != null) {
+      final io.confluent.connect.storage.hive.HiveUtil newHiveUtil
+              = newFormat.getHiveFactory().createHiveUtil(connectorConfig, hiveMetaStore);
+      hive = new HiveUtil(connectorConfig, hiveMetaStore) {
+        @Override
+        public void createTable(
+                String database, String tableName, Schema schema,
+                Partitioner partitioner
+        ) {
+          newHiveUtil.createTable(database, tableName, schema, partitioner);
+        }
+
+        @Override
+        public void alterSchema(String database, String tableName, Schema schema) {
+          newHiveUtil.alterSchema(database, tableName, schema);
+        }
+      };
+    } else {
+      throw new ConnectException("One of old or new format classes must be provided");
+    }
+    executorService = Executors.newSingleThreadExecutor();
+    hiveUpdateFutures = new LinkedList<>();
+    if (connectorConfig.getBoolean(MULTI_SCHEMA_SUPPORT_CONFIG)) {
+      this.hiveTableNamingStrategy = new SchemaNameHiveTableNamingStrategy();
+    } else {
+      this.hiveTableNamingStrategy = new HiveTableNamingStrategy() {};
+    }
+    this.hiveServiceProvider = new HiveServiceProvider(partitioner, hiveTableNamingStrategy,
+            hiveMetaStore, hive, executorService, hiveUpdateFutures, connectorConfig);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void setupStorageFormat(HdfsSinkConnectorConfig connectorConfig, AvroData avroData)
+          throws InstantiationException, IllegalAccessException, InvocationTargetException,
+          NoSuchMethodException {
+    // Try to instantiate as a new-style storage-common type class, then fall back to old-style
+    // with no parameters
+    io.confluent.connect.storage.format.SchemaFileReader<HdfsSinkConnectorConfig, Path>
+            schemaFileReader;
+    RecordWriterProvider writerProvider = null;
+    io.confluent.connect.storage.format.RecordWriterProvider<HdfsSinkConnectorConfig>
+            newWriterProvider = null;
+    try {
+      Class<io.confluent.connect.storage.format.Format> formatClass =
+              (Class<io.confluent.connect.storage.format.Format>)
+                      connectorConfig.getClass(HdfsSinkConnectorConfig.FORMAT_CLASS_CONFIG);
+
+      newFormat = formatClass.getConstructor(HdfsStorage.class).newInstance(storage);
+      newWriterProvider = newFormat.getRecordWriterProvider();
+      schemaFileReader = newFormat.getSchemaFileReader();
+    } catch (NoSuchMethodException e) {
+      Class<Format> formatClass =
+              (Class<Format>) connectorConfig.getClass(HdfsSinkConnectorConfig.FORMAT_CLASS_CONFIG);
+      format = formatClass.getConstructor().newInstance();
+      writerProvider = format.getRecordWriterProvider();
+      final io.confluent.connect.hdfs.SchemaFileReader oldReader
+              = format.getSchemaFileReader(avroData);
+      schemaFileReader = new SchemaFileReader<HdfsSinkConnectorConfig, Path>() {
+        @Override
+        public Schema getSchema(HdfsSinkConnectorConfig hdfsSinkConnectorConfig, Path path) {
+          try {
+            return oldReader.getSchema(hdfsSinkConnectorConfig.getHadoopConfiguration(), path);
+          } catch (IOException e) {
+            throw new ConnectException("Failed to get schema", e);
+          }
+        }
+
+        @Override
+        public Iterator<Object> iterator() {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasNext() {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object next() {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void remove() {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() throws IOException {}
+      };
+    }
+    this.recoerdWriterProvider = new SelectableRecordWriterProvider(this.storage.conf(), avroData,
+            newWriterProvider, writerProvider);
+    this.schemaResolutionStrategyProvider = new SchemaResolutionStrategyProvider(storage,
+            connectorConfig, schemaFileReader);
   }
 
   public void write(Collection<SinkRecord> records) {
@@ -387,28 +415,21 @@ public class DataWriter {
 
     try {
       for (String topic : topics) {
-        String topicDir = FileUtils.topicDirectory(url, topicsDir, topic);
-        CommittedFileFilter filter = new TopicCommittedFileFilter(topic);
-        FileStatus fileStatusWithMaxOffset = FileUtils.fileStatusWithMaxOffset(
-            storage,
-            new Path(topicDir),
-            filter
-        );
-        if (fileStatusWithMaxOffset != null) {
-          final Path path = fileStatusWithMaxOffset.getPath();
-          final Schema latestSchema;
-          latestSchema = schemaFileReader.getSchema(
-              connectorConfig,
-              path
-          );
+        for (Schema latestSchema : readSchemas(topic)) {
           hive.createTable(hiveDatabase, topic, latestSchema, partitioner);
-          List<String> partitions = hiveMetaStore.listPartitions(hiveDatabase, topic, (short) -1);
-          FileStatus[] statuses = FileUtils.getDirectories(storage, new Path(topicDir));
+          String hiveTableName = hiveTableNamingStrategy.createName(
+                  new HiveTableNamingParameters(topic, latestSchema)
+          );
+          List<String> partitions = hiveMetaStore.listPartitions(hiveDatabase, hiveTableName,
+                  (short) -1
+          );
+          String topicDirPath = createTopicDirectoryName(topic, latestSchema);
+          FileStatus[] statuses = FileUtils.getDirectories(storage, new Path(topicDirPath));
           for (FileStatus status : statuses) {
             String location = status.getPath().toString();
             if (!partitions.contains(location)) {
               String partitionValue = getPartitionValue(location);
-              hiveMetaStore.addPartition(hiveDatabase, topic, partitionValue);
+              hiveMetaStore.addPartition(hiveDatabase, hiveTableName, partitionValue);
             }
           }
         }
@@ -418,23 +439,57 @@ public class DataWriter {
     }
   }
 
+  private List<Schema> readSchemas(String topic) {
+    SchemaResolutionStrategy schemaResolutionStrategy =
+            schemaResolutionStrategyProvider.get(topic, true);
+    if (connectorConfig.getBoolean(MULTI_SCHEMA_SUPPORT_CONFIG)) {
+      return findStoredSchemaNames(topic).stream()
+              .map(schemaName -> schemaResolutionStrategy.getOrLoadCurrentSchema(schemaName, 0))
+              .filter(Optional::isPresent)
+              .map(Optional::get)
+              .collect(toList());
+    } else {
+      return schemaResolutionStrategy.getOrLoadCurrentSchema(null, 0)
+              .map(Collections::singletonList)
+              .orElse(emptyList());
+    }
+  }
+
+  private List<String> findStoredSchemaNames(String topic) {
+    String topicDir = topicDirectory(url, topicsDir, topic);
+    List<FileStatus> files = storage.list(topicDir);
+    List<String> schemas = new ArrayList<>();
+    for (FileStatus typeDirectory : files) {
+      if (!typeDirectory.isDirectory()) {
+        throw new ConnectException("Path " + typeDirectory.getPath().toString()
+                + " is not supported for multi schema integration."
+                + " Path should consist of type name.");
+      }
+      schemas.add(typeDirectory.getPath().getName());
+    }
+    return schemas;
+  }
+
+  private String createTopicDirectoryName(String topic, Schema latestSchema) {
+    String topicDir = topicDirectory(url, topicsDir, topic);
+    if (connectorConfig.getBoolean(MULTI_SCHEMA_SUPPORT_CONFIG)) {
+      return topicDir + "/" + latestSchema.name();
+    }
+    return topicDir;
+  }
+
   public void open(Collection<TopicPartition> partitions) {
     assignment = new HashSet<>(partitions);
     for (TopicPartition tp : assignment) {
       TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
           tp,
           storage,
-          writerProvider,
-          newWriterProvider,
+          recoerdWriterProvider,
           partitioner,
           connectorConfig,
           context,
-          avroData,
-          hiveMetaStore,
-          hive,
-          schemaFileReader,
-          executorService,
-          hiveUpdateFutures,
+          schemaResolutionStrategyProvider.get(tp),
+          hiveServiceProvider != null ? hiveServiceProvider.get(tp) : null,
           time
       );
       topicPartitionWriters.put(tp, topicPartitionWriter);
@@ -595,37 +650,5 @@ public class DataWriter {
       sb.append("/");
     }
     return sb.toString();
-  }
-
-  private Partitioner createPartitioner(HdfsSinkConnectorConfig config)
-      throws ClassNotFoundException, IllegalAccessException, InstantiationException {
-
-    @SuppressWarnings("unchecked")
-    Class<? extends Partitioner> partitionerClasss = (Class<? extends Partitioner>)
-        Class.forName(config.getString(PartitionerConfig.PARTITIONER_CLASS_CONFIG));
-
-    Map<String, Object> map = copyConfig(config);
-    Partitioner partitioner = partitionerClasss.newInstance();
-    partitioner.configure(map);
-    return partitioner;
-  }
-
-  private Map<String, Object> copyConfig(HdfsSinkConnectorConfig config) {
-    Map<String, Object> map = new HashMap<>();
-    map.put(
-        PartitionerConfig.PARTITION_FIELD_NAME_CONFIG,
-        config.getString(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG)
-    );
-    map.put(
-        PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
-        config.getLong(PartitionerConfig.PARTITION_DURATION_MS_CONFIG)
-    );
-    map.put(
-        PartitionerConfig.PATH_FORMAT_CONFIG,
-        config.getString(PartitionerConfig.PATH_FORMAT_CONFIG)
-    );
-    map.put(PartitionerConfig.LOCALE_CONFIG, config.getString(PartitionerConfig.LOCALE_CONFIG));
-    map.put(PartitionerConfig.TIMEZONE_CONFIG, config.getString(PartitionerConfig.TIMEZONE_CONFIG));
-    return map;
   }
 }

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -105,6 +105,11 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
   private static final String HDFS_NAMENODE_PRINCIPAL_DOC = "The principal for HDFS Namenode.";
   private static final String HDFS_NAMENODE_PRINCIPAL_DISPLAY = "HDFS NameNode Kerberos Principal";
 
+  public static final String MULTI_SCHEMA_SUPPORT_CONFIG = "multi.schema.support";
+  public static final String MULTI_SCHEMA_SUPPORT_DOC = "Multiple schema support on one topic.";
+  public static final boolean MULTI_SCHEMA_SUPPORT_DEFAULT = false;
+  public static final String MULTI_SCHEMA_SUPPORT_DISPLAY = "Multiple schema support";
+
   public static final String KERBEROS_TICKET_RENEW_PERIOD_MS_CONFIG =
       "kerberos.ticket.renew.period.ms";
   public static final long KERBEROS_TICKET_RENEW_PERIOD_MS_DEFAULT = 60000 * 60;
@@ -202,6 +207,10 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     }
 
     {
+      createMultiSchemaConfigDefinition(configDef);
+    }
+
+    {
       final String group = "Security";
       int orderInGroup = 0;
       // Define Security configuration group
@@ -284,6 +293,19 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
       configDef.define(key);
     }
     return configDef;
+  }
+
+  private static void createMultiSchemaConfigDefinition(ConfigDef configDef) {
+    configDef.define(
+        MULTI_SCHEMA_SUPPORT_CONFIG,
+        Type.BOOLEAN,
+        MULTI_SCHEMA_SUPPORT_DEFAULT,
+        Importance.LOW,
+        MULTI_SCHEMA_SUPPORT_DOC,
+        "Other", 1,
+        Width.SHORT,
+        MULTI_SCHEMA_SUPPORT_DISPLAY
+    );
   }
 
   private final String name;

--- a/src/main/java/io/confluent/connect/hdfs/SelectableRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/SelectableRecordWriterProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs;
+
+import io.confluent.connect.avro.AvroData;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.io.IOException;
+
+public class SelectableRecordWriterProvider {
+  private final HdfsSinkConnectorConfig connectorConfig;
+  private final AvroData avroData;
+
+  private final io.confluent.connect.storage.format.RecordWriterProvider<HdfsSinkConnectorConfig>
+          newWriterProvider;
+  // This is one case where we cannot simply wrap the old or new RecordWriterProvider with the
+  // other because they have incompatible requirements for some methods -- one requires the Hadoop
+  // config + extra parameters, the other requires the ConnectorConfig and doesn't get the other
+  // extra parameters. Instead, we have to (optionally) store one of each and use whichever one is
+  // non-null.
+  private final RecordWriterProvider writerProvider;
+
+  public SelectableRecordWriterProvider(HdfsSinkConnectorConfig connectorConfig, AvroData avroData,
+         io.confluent.connect.storage.format.RecordWriterProvider<HdfsSinkConnectorConfig>
+                 newWriterProvider, RecordWriterProvider writerProvider) {
+    this.connectorConfig = connectorConfig;
+    this.avroData = avroData;
+    this.newWriterProvider = newWriterProvider;
+    this.writerProvider = writerProvider;
+  }
+
+  public String getExtension() {
+    if (writerProvider != null) {
+      return writerProvider.getExtension();
+    } else if (newWriterProvider != null) {
+      return newWriterProvider.getExtension();
+    } else {
+      throw new ConnectException(
+              "Invalid state: either old or new RecordWriterProvider must be provided"
+      );
+    }
+  }
+
+  io.confluent.connect.storage.format.RecordWriter getRecordWriter(String fileName,
+                                                                   SinkRecord record)
+          throws IOException {
+    if (writerProvider != null) {
+      return new OldRecordWriterWrapper(
+              writerProvider.getRecordWriter(
+                      connectorConfig.getHadoopConfiguration(),
+                      fileName,
+                      record,
+                      avroData
+              )
+      );
+    } else if (newWriterProvider != null) {
+      return newWriterProvider.getRecordWriter(connectorConfig, fileName);
+    } else {
+      throw new ConnectException(
+              "Invalid state: either old or new RecordWriterProvider must be provided"
+      );
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/filter/SchemaTypeFilterDecorator.java
+++ b/src/main/java/io/confluent/connect/hdfs/filter/SchemaTypeFilterDecorator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.filter;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+
+public class SchemaTypeFilterDecorator extends CommittedFileFilter {
+  private PathFilter pathFilter;
+  private String schemaName;
+
+  public SchemaTypeFilterDecorator(PathFilter pathFilter, String schemaName) {
+    this.schemaName = schemaName;
+    this.pathFilter = pathFilter;
+  }
+
+  @Override
+  public boolean accept(Path path) {
+    if (!pathFilter.accept(path)) {
+      return false;
+    }
+    return path.getName().contains(schemaName);
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/hive/HiveService.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/HiveService.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.connect.hdfs.hive;
+
+import io.confluent.connect.hdfs.partitioner.Partitioner;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+public class HiveService {
+  private static final Logger log = LoggerFactory.getLogger(HiveService.class);
+  private final TopicPartition tp;
+  private final Partitioner hivePartitioner;
+  private final HiveTableNamingStrategy hiveTableNamingStrategy;
+  private final String hiveDatabase;
+  private final HiveMetaStore hiveMetaStore;
+  private final HiveUtil hive;
+  private final ExecutorService executorService;
+  private final Queue<Future<Void>> hiveUpdateFutures;
+
+  public HiveService(TopicPartition tp, Partitioner hivePartitioner,
+                     HiveTableNamingStrategy hiveTableNamingStrategy, HiveMetaStore hiveMetaStore,
+                     HiveUtil hive, ExecutorService executorService,
+                     Queue<Future<Void>> hiveUpdateFutures,
+                     String hiveDatabase) {
+    this.tp = tp;
+    this.hivePartitioner = hivePartitioner;
+    this.hiveTableNamingStrategy = hiveTableNamingStrategy;
+    this.hiveDatabase = hiveDatabase;
+    this.hiveMetaStore = hiveMetaStore;
+    this.hive = hive;
+    this.executorService = executorService;
+    this.hiveUpdateFutures = hiveUpdateFutures;
+  }
+
+  public void createHiveTable(Schema schema) {
+    Future<Void> future = executorService.submit(() -> {
+      try {
+        hive.createTable(hiveDatabase, tp.topic(), schema, hivePartitioner);
+      } catch (Throwable e) {
+        log.error("Creating Hive table threw unexpected error", e);
+      }
+      return null;
+    });
+    hiveUpdateFutures.add(future);
+  }
+
+  public void alterHiveSchema(Schema schema) {
+    Future<Void> future = executorService.submit(() -> {
+      try {
+        String tableName = hiveTableNamingStrategy.createName(
+                new HiveTableNamingParameters(tp.topic(), schema)
+        );
+        hive.alterSchema(hiveDatabase, tableName, schema);
+      } catch (Throwable e) {
+        log.error("Altering Hive schema threw unexpected error", e);
+      }
+      return null;
+    });
+    hiveUpdateFutures.add(future);
+  }
+
+  public void addHivePartition(final SinkRecord record, Schema schema) {
+    String location = hivePartitioner.encodePartition(record);
+    Future<Void> future = executorService.submit(() -> {
+      try {
+        String tableName = hiveTableNamingStrategy.createName(
+                new HiveTableNamingParameters(tp.topic(), schema)
+        );
+        hiveMetaStore.addPartition(hiveDatabase, tableName, location);
+      } catch (Throwable e) {
+        log.error("Adding Hive partition threw unexpected error", e);
+      }
+      return null;
+    });
+    hiveUpdateFutures.add(future);
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/hive/HiveServiceProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/HiveServiceProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.connect.hdfs.hive;
+
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.hdfs.partitioner.Partitioner;
+import io.confluent.connect.storage.hive.HiveConfig;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+public class HiveServiceProvider {
+  private final Partitioner hivePartitioner;
+  private final HiveTableNamingStrategy hiveTableNamingStrategy;
+  private final String hiveDatabase;
+  private final HiveMetaStore hiveMetaStore;
+  private final HiveUtil hive;
+  private final ExecutorService executorService;
+  private final Queue<Future<Void>> hiveUpdateFutures;
+
+  public HiveServiceProvider(Partitioner hivePartitioner,
+                             HiveTableNamingStrategy hiveTableNamingStrategy,
+                             HiveMetaStore hiveMetaStore, HiveUtil hive,
+                             ExecutorService executorService,
+                             Queue<Future<Void>> hiveUpdateFutures,
+                             HdfsSinkConnectorConfig connectorConfig) {
+    this.hivePartitioner = hivePartitioner;
+    this.hiveTableNamingStrategy = hiveTableNamingStrategy;
+    if (connectorConfig.getBoolean(HiveConfig.HIVE_INTEGRATION_CONFIG)) {
+      this.hiveDatabase = connectorConfig.getString(HiveConfig.HIVE_DATABASE_CONFIG);
+    } else {
+      this.hiveDatabase = null;
+    }
+    this.hiveMetaStore = hiveMetaStore;
+    this.hive = hive;
+    this.executorService = executorService;
+    this.hiveUpdateFutures = hiveUpdateFutures;
+  }
+
+  public HiveService get(TopicPartition tp) {
+    return new HiveService(tp, hivePartitioner, hiveTableNamingStrategy, hiveMetaStore, hive,
+            executorService, hiveUpdateFutures, hiveDatabase);
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/hive/HiveTableNamingParameters.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/HiveTableNamingParameters.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.hive;
+
+import org.apache.kafka.connect.data.Schema;
+
+public class HiveTableNamingParameters {
+  private String topicName;
+  private Schema schema;
+
+  public HiveTableNamingParameters(String topicName, Schema schema) {
+    this.topicName = topicName;
+    this.schema = schema;
+  }
+
+  public String getTopicName() {
+    return topicName;
+  }
+
+  public Schema getSchema() {
+    return schema;
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/hive/HiveTableNamingStrategy.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/HiveTableNamingStrategy.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.hive;
+
+public interface HiveTableNamingStrategy {
+  default String createName(HiveTableNamingParameters parameters) {
+    return parameters.getTopicName();
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/hive/HiveUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/HiveUtil.java
@@ -42,16 +42,16 @@ public abstract class HiveUtil extends io.confluent.connect.storage.hive.HiveUti
   @Override
   public void createTable(
       String database,
-      String tableName,
+      String topicName,
       Schema schema,
       io.confluent.connect.storage.partitioner.Partitioner<FieldSchema> partitioner
   ) {
-    createTable(database, tableName, schema, (Partitioner) partitioner);
+    createTable(database, topicName, schema, (Partitioner) partitioner);
   }
 
   public abstract void createTable(
       String database,
-      String tableName,
+      String topicName,
       Schema schema,
       Partitioner partitioner
   );

--- a/src/main/java/io/confluent/connect/hdfs/hive/SchemaNameHiveTableNamingStrategy.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/SchemaNameHiveTableNamingStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.hive;
+
+public class SchemaNameHiveTableNamingStrategy implements HiveTableNamingStrategy {
+  @Override
+  public String createName(HiveTableNamingParameters parameters) {
+    String schemaFullName = parameters.getSchema().name();
+    int startIndex = schemaFullName.lastIndexOf('.');
+    return schemaFullName.substring(startIndex == -1 ? 0 : startIndex).toLowerCase();
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/partitioner/SchemaAwarePartitionerDecorator.java
+++ b/src/main/java/io/confluent/connect/hdfs/partitioner/SchemaAwarePartitionerDecorator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.partitioner;
+
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.List;
+import java.util.Map;
+
+public class SchemaAwarePartitionerDecorator implements Partitioner {
+  private Partitioner partitioner;
+
+  public SchemaAwarePartitionerDecorator(Partitioner partitioner) {
+    this.partitioner = partitioner;
+  }
+
+  @Override
+  public void configure(Map<String, Object> config) {
+    partitioner.configure(config);
+  }
+
+  @Override
+  public String encodePartition(SinkRecord sinkRecord) {
+    return sinkRecord.valueSchema().name() + "/" + partitioner.encodePartition(sinkRecord);
+  }
+
+  @Override
+  public String generatePartitionedPath(String topic, String encodedPartition) {
+    return partitioner.generatePartitionedPath(topic, encodedPartition);
+  }
+
+  @Override
+  public List<FieldSchema> partitionFields() {
+    return partitioner.partitionFields();
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/schema/MultipleSchemasContainer.java
+++ b/src/main/java/io/confluent/connect/hdfs/schema/MultipleSchemasContainer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.schema;
+
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.hdfs.filter.CommittedFileFilter;
+import io.confluent.connect.hdfs.filter.SchemaTypeFilterDecorator;
+import io.confluent.connect.hdfs.storage.Storage;
+import io.confluent.connect.storage.format.SchemaFileReader;
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class MultipleSchemasContainer extends SchemaResolutionAbstract
+        implements SchemaResolutionStrategy {
+  private final CommittedFileFilter committedFileFilter;
+  private boolean readSchemaFromFile;
+  private final Map<String, Schema> currentSchemas = new HashMap<>();
+
+  public MultipleSchemasContainer(Storage storage, HdfsSinkConnectorConfig connectorConfig,
+                                  String topic, SchemaFileReader<HdfsSinkConnectorConfig,
+                                  Path> schemaFileReader, CommittedFileFilter committedFileFilter,
+                                  boolean readSchemaFromFile) {
+    super(storage, connectorConfig, topic, schemaFileReader);
+
+    this.committedFileFilter = committedFileFilter;
+    this.readSchemaFromFile = readSchemaFromFile;
+  }
+
+  @Override
+  public Optional<Schema> getOrLoadCurrentSchema(String recordSchemaName, long offset) {
+    Optional<Schema> currentSchema = Optional.ofNullable(currentSchemas.get(recordSchemaName));
+    if (!currentSchema.isPresent() && readSchemaFromFile && offset != -1) {
+      currentSchema = readSchemaFromFile(
+              new SchemaTypeFilterDecorator(committedFileFilter, recordSchemaName)
+      );
+      currentSchema.ifPresent(schema -> currentSchemas.put(recordSchemaName, schema));
+    }
+    return currentSchema;
+  }
+
+  @Override
+  public void update(Schema schema) {
+    currentSchemas.put(schema.name(), schema);
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/schema/SchemaResolutionAbstract.java
+++ b/src/main/java/io/confluent/connect/hdfs/schema/SchemaResolutionAbstract.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.schema;
+
+import io.confluent.connect.hdfs.FileUtils;
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.hdfs.filter.CommittedFileFilter;
+import io.confluent.connect.hdfs.storage.Storage;
+import io.confluent.connect.storage.format.SchemaFileReader;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Optional;
+
+import static io.confluent.connect.hdfs.FileUtils.fileStatusWithMaxOffset;
+import static io.confluent.connect.storage.common.StorageCommonConfig.TOPICS_DIR_CONFIG;
+
+public abstract class SchemaResolutionAbstract implements SchemaResolutionStrategy {
+  protected final String topic;
+  private final Storage storage;
+  private final SchemaFileReader<HdfsSinkConnectorConfig, Path> schemaFileReader;
+  private final String topicsDir;
+  private final HdfsSinkConnectorConfig connectorConfig;
+
+  protected SchemaResolutionAbstract(Storage storage, HdfsSinkConnectorConfig connectorConfig,
+                                     String topic, SchemaFileReader<HdfsSinkConnectorConfig,
+                                     Path> schemaFileReader) {
+    this.storage = storage;
+    this.connectorConfig = connectorConfig;
+    this.topicsDir = connectorConfig.getString(TOPICS_DIR_CONFIG);
+    this.topic = topic;
+    this.schemaFileReader = schemaFileReader;
+  }
+
+  protected Optional<Schema> readSchemaFromFile(CommittedFileFilter filter) {
+    String topicDir = FileUtils.topicDirectory(storage.url(), topicsDir, topic);
+    FileStatus fileStatusWithMaxOffset = fileStatusWithMaxOffset(
+            storage, new Path(topicDir), filter
+    );
+    if (fileStatusWithMaxOffset != null) {
+      return Optional.of(
+              schemaFileReader.getSchema(connectorConfig, fileStatusWithMaxOffset.getPath())
+      );
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/schema/SchemaResolutionStrategy.java
+++ b/src/main/java/io/confluent/connect/hdfs/schema/SchemaResolutionStrategy.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.schema;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Optional;
+
+public interface SchemaResolutionStrategy {
+  Optional<Schema> getOrLoadCurrentSchema(String recordSchemaName, long offset);
+
+  void update(Schema schema);
+}

--- a/src/main/java/io/confluent/connect/hdfs/schema/SchemaResolutionStrategyProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/schema/SchemaResolutionStrategyProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.schema;
+
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.hdfs.filter.CommittedFileFilter;
+import io.confluent.connect.hdfs.filter.TopicCommittedFileFilter;
+import io.confluent.connect.hdfs.filter.TopicPartitionCommittedFileFilter;
+import io.confluent.connect.hdfs.storage.HdfsStorage;
+import io.confluent.connect.storage.format.SchemaFileReader;
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.common.TopicPartition;
+
+import static io.confluent.connect.hdfs.HdfsSinkConnectorConfig.MULTI_SCHEMA_SUPPORT_CONFIG;
+import static io.confluent.connect.storage.hive.HiveConfig.SCHEMA_COMPATIBILITY_CONFIG;
+import static io.confluent.connect.storage.schema.StorageSchemaCompatibility.NONE;
+import static io.confluent.connect.storage.schema.StorageSchemaCompatibility.getCompatibility;
+
+public class SchemaResolutionStrategyProvider {
+  private HdfsStorage storage;
+  private HdfsSinkConnectorConfig connectorConfig;
+  private SchemaFileReader<HdfsSinkConnectorConfig, Path> schemaFileReader;
+
+  public SchemaResolutionStrategyProvider(HdfsStorage storage,
+                                          HdfsSinkConnectorConfig connectorConfig,
+                                          SchemaFileReader<HdfsSinkConnectorConfig, Path>
+                                                  schemaFileReader) {
+    this.storage = storage;
+    this.connectorConfig = connectorConfig;
+    this.schemaFileReader = schemaFileReader;
+  }
+
+  public SchemaResolutionStrategy get(TopicPartition topicPartition) {
+    boolean readSchemaFromFile = getCompatibility(
+            connectorConfig.getString(SCHEMA_COMPATIBILITY_CONFIG)) != NONE;
+    CommittedFileFilter filter = new TopicPartitionCommittedFileFilter(topicPartition);
+    if (connectorConfig.getBoolean(MULTI_SCHEMA_SUPPORT_CONFIG)) {
+      return new MultipleSchemasContainer(storage, connectorConfig, topicPartition.topic(),
+              schemaFileReader, filter, readSchemaFromFile);
+    } else {
+      return new SingleSchemaContainer(storage, connectorConfig, topicPartition.topic(),
+              schemaFileReader, filter, readSchemaFromFile);
+    }
+  }
+
+  public SchemaResolutionStrategy get(String topic, boolean readSchemaFromFile) {
+    if (connectorConfig.getBoolean(MULTI_SCHEMA_SUPPORT_CONFIG)) {
+      return new MultipleSchemasContainer(storage, connectorConfig, topic, schemaFileReader,
+              new TopicCommittedFileFilter(topic), readSchemaFromFile);
+    } else {
+      return new SingleSchemaContainer(storage, connectorConfig, topic, schemaFileReader,
+              new TopicCommittedFileFilter(topic), readSchemaFromFile);
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/schema/SingleSchemaContainer.java
+++ b/src/main/java/io/confluent/connect/hdfs/schema/SingleSchemaContainer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.schema;
+
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.hdfs.filter.CommittedFileFilter;
+import io.confluent.connect.hdfs.storage.Storage;
+import io.confluent.connect.storage.format.SchemaFileReader;
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Optional;
+
+public class SingleSchemaContainer extends SchemaResolutionAbstract
+        implements SchemaResolutionStrategy {
+  private final CommittedFileFilter committedFileFilter;
+  private boolean readSchemaFromFile;
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private Optional<Schema> currentSchema = Optional.empty();
+
+  public SingleSchemaContainer(Storage storage, HdfsSinkConnectorConfig connectorConfig,
+                               String topic,
+                               SchemaFileReader<HdfsSinkConnectorConfig, Path> schemaFileReader,
+                               CommittedFileFilter committedFileFilter,
+                               boolean readSchemaFromFile) {
+    super(storage, connectorConfig, topic, schemaFileReader);
+    this.committedFileFilter = committedFileFilter;
+    this.readSchemaFromFile = readSchemaFromFile;
+  }
+
+  @Override
+  public Optional<Schema> getOrLoadCurrentSchema(String recordSchemaName, long offset) {
+    if (!currentSchema.isPresent() && readSchemaFromFile && offset != -1) {
+      currentSchema = readSchemaFromFile(committedFileFilter);
+    }
+    return currentSchema;
+  }
+
+  @Override
+  public void update(Schema schema) {
+    this.currentSchema = Optional.of(schema);
+  }
+}

--- a/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
@@ -42,6 +42,7 @@ import io.confluent.connect.hdfs.filter.TopicPartitionCommittedFileFilter;
 import io.confluent.connect.hdfs.partitioner.Partitioner;
 import io.confluent.connect.storage.common.StorageCommonConfig;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -104,6 +105,10 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
    * @param size the number of records to return.
    * @return the list of records.
    */
+  protected List<SinkRecord> createSinkRecords(int size, Schema schema) {
+    return createSinkRecords(size, 0, Collections.singleton(new TopicPartition(TOPIC, PARTITION)), schema);
+  }
+
   protected List<SinkRecord> createSinkRecords(int size) {
     return createSinkRecords(size, 0);
   }
@@ -129,6 +134,10 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
    */
   protected List<SinkRecord> createSinkRecords(int size, long startOffset, Set<TopicPartition> partitions) {
     Schema schema = createSchema();
+    return createSinkRecords(size, startOffset, partitions, schema);
+  }
+
+  protected List<SinkRecord> createSinkRecords(int size, long startOffset, Set<TopicPartition> partitions, Schema schema) {
     Struct record = createRecord(schema);
     List<Struct> same = new ArrayList<>();
     for (int i = 0; i < size; ++i) {
@@ -262,12 +271,14 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
    * offsets equals the expected size of the file, and last offset is exclusive.
    */
   protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets) throws IOException {
-    verify(sinkRecords, validOffsets, Collections.singleton(new TopicPartition(TOPIC, PARTITION)), false);
+    verify(sinkRecords, singletonList(new VerificationParameter(validOffsets, new TopicPartition(TOPIC, PARTITION))), false);
   }
 
   protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions)
       throws IOException {
-    verify(sinkRecords, validOffsets, partitions, false);
+    List<VerificationParameter> parameters = new ArrayList<>();
+    partitions.forEach(partition -> parameters.add(new VerificationParameter(validOffsets, partition)));
+    verify(sinkRecords, parameters, false);
   }
 
   /**
@@ -275,23 +286,25 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
    *
    * @param sinkRecords a flat list of the records that need to appear in potentially several *
    * files in HDFS.
-   * @param validOffsets an array containing the offsets that map to uploaded files for a
+   * @param parameters contains validOffsets, partitions and schema
+   * validOffsets an array containing the offsets that map to uploaded files for a
    * topic-partition. Offsets appear in ascending order, the difference between two consecutive
    * offsets equals the expected size of the file, and last offset is exclusive.
-   * @param partitions the set of partitions to verify records for.
+   * partitions the set of partitions to verify records for.
+   * schema used for writen data (only for multi schema support
    */
-  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,
+  protected void verify(List<SinkRecord> sinkRecords, List<VerificationParameter> parameters,
                         boolean skipFileListing) throws IOException {
     if (!skipFileListing) {
-      verifyFileListing(validOffsets, partitions);
+      verifyFileListing(parameters);
     }
 
-    for (TopicPartition tp : partitions) {
-      for (int i = 1, j = 0; i < validOffsets.length; ++i) {
-        long startOffset = validOffsets[i - 1];
-        long endOffset = validOffsets[i] - 1;
+    for (VerificationParameter parameter : parameters) {
+      for (int i = 1, j = 0; i < parameter.validOffsets.length; ++i) {
+        long startOffset = parameter.validOffsets[i - 1];
+        long endOffset = parameter.validOffsets[i] - 1;
 
-        String filename = FileUtils.committedFileName(url, topicsDir, getDirectory(tp.topic(), tp.partition()), tp,
+        String filename = FileUtils.committedFileName(url, topicsDir, getSchemaAwareDirectory(parameter.tp, parameter.schema), parameter.tp,
                                                       startOffset, endOffset, extension, zeroPadFormat);
         Path path = new Path(filename);
         Collection<Object> records = dataFileReader.readData(connectorConfig.getHadoopConfiguration(), path);
@@ -315,18 +328,47 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
     return expectedFiles;
   }
 
-  protected void verifyFileListing(long[] validOffsets, Set<TopicPartition> partitions) throws IOException {
-    for (TopicPartition tp : partitions) {
-      verifyFileListing(getExpectedFiles(validOffsets, tp), tp);
+  protected List<String> getExpectedFiles(VerificationParameter parameter) {
+    List<String> expectedFiles = new ArrayList<>();
+    for (int i = 1; i < parameter.validOffsets.length; ++i) {
+      long startOffset = parameter.validOffsets[i - 1];
+      long endOffset = parameter.validOffsets[i] - 1;
+      expectedFiles.add(FileUtils.committedFileName(url, topicsDir, getSchemaAwareDirectory(parameter.tp, parameter.schema), parameter.tp,
+              startOffset, endOffset, extension, zeroPadFormat));
+    }
+    return expectedFiles;
+  }
+
+  protected class VerificationParameter {
+    private long[] validOffsets;
+    private TopicPartition tp;
+    private Schema schema;
+
+    public VerificationParameter(long[] validOffsets, TopicPartition tp) {
+      this.tp = tp;
+      this.validOffsets = validOffsets;
+    }
+
+    public VerificationParameter(long[] validOffsets, TopicPartition tp, Schema schema) {
+      this.validOffsets = validOffsets;
+      this.tp = tp;
+      this.schema = schema;
     }
   }
 
-  protected void verifyFileListing(List<String> expectedFiles, TopicPartition tp) throws IOException {
+  protected void verifyFileListing(List<VerificationParameter> parameters) throws IOException {
+    for (VerificationParameter parameter : parameters) {
+      verifyFileListing(getExpectedFiles(parameter), parameter);
+    }
+  }
+
+  protected void verifyFileListing(List<String> expectedFiles, VerificationParameter parameter) throws IOException {
     FileStatus[] statuses = {};
     try {
+      String directory = getSchemaAwareDirectory(parameter.tp, parameter.schema);
       statuses = fs.listStatus(
-          new Path(FileUtils.directoryName(url, topicsDir, getDirectory(tp.topic(), tp.partition()))),
-          new TopicPartitionCommittedFileFilter(tp));
+          new Path(FileUtils.directoryName(url, topicsDir, directory)),
+          new TopicPartitionCommittedFileFilter(parameter.tp));
     } catch (FileNotFoundException e) {
       // the directory does not exist.
     }
@@ -339,6 +381,14 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
     Collections.sort(actualFiles);
     Collections.sort(expectedFiles);
     assertThat(actualFiles, is(expectedFiles));
+  }
+
+  protected String getSchemaAwareDirectory(TopicPartition tp, Schema schema) {
+    String topic = tp.topic();
+    if (schema != null) {
+      topic = topic + "/" + schema.name();
+    }
+    return getDirectory(topic, tp.partition());
   }
 
   protected void verifyContents(List<SinkRecord> expectedRecords, int startIndex, Collection<Object> records) {
@@ -354,4 +404,13 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
     }
   }
 
+  protected Schema createSchema(String name) {
+    return SchemaBuilder.struct().name(name).version(1)
+            .field("boolean", Schema.BOOLEAN_SCHEMA)
+            .field("int", Schema.INT32_SCHEMA)
+            .field("long", Schema.INT64_SCHEMA)
+            .field("float", Schema.FLOAT32_SCHEMA)
+            .field("double", Schema.FLOAT64_SCHEMA)
+            .build();
+  }
 }

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -17,12 +17,15 @@ package io.confluent.connect.hdfs.avro;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +46,8 @@ import io.confluent.connect.storage.hive.HiveConfig;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
 
+import static io.confluent.connect.hdfs.HdfsSinkConnectorConfig.MULTI_SCHEMA_SUPPORT_CONFIG;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -112,7 +117,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     hdfsWriter.stop();
 
     long[] validOffsets = {0, 10, 20, 30, 40, 50, 53};
-    verifyFileListing(validOffsets, Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
+    verifyFileListing(singletonList(new VerificationParameter(validOffsets, new TopicPartition(TOPIC, PARTITION))));
   }
 
   @Test
@@ -247,7 +252,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
 
     // Last file (offset 6) doesn't satisfy size requirement and gets discarded on close
     long[] validOffsetsTopicPartition2 = {0, 3, 6};
-    verify(sinkRecords, validOffsetsTopicPartition2, Collections.singleton(TOPIC_PARTITION2), true);
+    verify(sinkRecords, singletonList(new VerificationParameter(validOffsetsTopicPartition2, TOPIC_PARTITION2)), true);
 
     // Message offsets start at 6 because we discarded the in-progress temp file on re-balance
     sinkRecords = createSinkRecords(3, 6, context.assignment());
@@ -258,10 +263,10 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
 
     // Last file (offset 9) doesn't satisfy size requirement and gets discarded on close
     long[] validOffsetsTopicPartition1 = {6, 9};
-    verify(sinkRecords, validOffsetsTopicPartition1, Collections.singleton(TOPIC_PARTITION), true);
+    verify(sinkRecords, singletonList(new VerificationParameter(validOffsetsTopicPartition1, TOPIC_PARTITION)), true);
 
     long[] validOffsetsTopicPartition3 = {6, 9};
-    verify(sinkRecords, validOffsetsTopicPartition3, Collections.singleton(TOPIC_PARTITION3), true);
+    verify(sinkRecords, singletonList(new VerificationParameter(validOffsetsTopicPartition3, TOPIC_PARTITION3)), true);
   }
 
   @Test
@@ -438,6 +443,77 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
         assertTrue((index = fileContents.indexOf("avro.codec")) > 0
             && fileContents.indexOf("snappy", index) > 0);
       }
+    }
+  }
+
+  @Test
+  public void testWriteRecordWithDifferentSchemas() throws Exception {
+    Map<String, String> props = createProps();
+    props.put(MULTI_SCHEMA_SUPPORT_CONFIG, "true");
+    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
+
+    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
+    hdfsWriter.recover(TOPIC_PARTITION);
+
+    Schema schema1 = createSchema();
+    List<SinkRecord> sinkRecords1 = createSinkRecords(4, schema1);
+    Schema schema2 = SchemaBuilder.struct().name("record2").version(1).field("boolean", Schema.BOOLEAN_SCHEMA).field("int", Schema.INT32_SCHEMA).field("long", Schema.INT64_SCHEMA).field("float", Schema.FLOAT32_SCHEMA).field("double", Schema.FLOAT64_SCHEMA).build();
+    List<SinkRecord> sinkRecords2 = createSinkRecords(3, schema2);
+
+    hdfsWriter.write(sinkRecords1);
+    hdfsWriter.write(sinkRecords2);
+    hdfsWriter.close();
+    hdfsWriter.stop();
+
+    verify(sinkRecords1, singletonList(new VerificationParameter(new long[] {0, 3, 4}, TOPIC_PARTITION, schema1)), false);
+    verify(sinkRecords2, singletonList(new VerificationParameter(new long[] {0, 3}, TOPIC_PARTITION, schema2)), false);
+  }
+
+  @Test
+  public void testRecoveryWithMultipleSchemas() throws Exception {
+    Map<String, String> props = createProps();
+    props.put(MULTI_SCHEMA_SUPPORT_CONFIG, "true");
+    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
+
+    HdfsStorage storage = new HdfsStorage(connectorConfig, url);
+    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    partitioner = hdfsWriter.getPartitioner();
+
+    WAL wal = storage.wal(logsDir, TOPIC_PARTITION);
+
+    wal.append(WAL.beginMarker, "");
+    Schema schema1 = createSchema();
+    Schema schema2 = createSchema("record2");
+    appendToWalFor(wal, schema1);
+    appendToWalFor(wal, schema2);
+    wal.append(WAL.endMarker, "");
+    wal.close();
+
+    hdfsWriter.recover(TOPIC_PARTITION);
+    Map<TopicPartition, Long> offsets = context.offsets();
+    assertTrue(offsets.containsKey(TOPIC_PARTITION));
+    assertEquals(50L, (long) offsets.get(TOPIC_PARTITION));
+
+    hdfsWriter.write(createSinkRecords(3, 50, Collections.singleton(new TopicPartition(TOPIC, PARTITION)), schema1));
+    hdfsWriter.write(createSinkRecords(3, 50, Collections.singleton(new TopicPartition(TOPIC, PARTITION)), schema2));
+    hdfsWriter.close();
+    hdfsWriter.stop();
+
+    long[] validOffsets = {0, 10, 20, 30, 40, 50, 53};
+    verifyFileListing(singletonList(new VerificationParameter(validOffsets, new TopicPartition(TOPIC, PARTITION), schema1)));
+    verifyFileListing(singletonList(new VerificationParameter(validOffsets, new TopicPartition(TOPIC, PARTITION), schema2)));
+  }
+
+  private void appendToWalFor(WAL wal, Schema schema1) throws IOException {
+    for (int i = 0; i < 5; ++i) {
+      long startOffset = i * 10;
+      long endOffset = (i + 1) * 10 - 1;
+      String tempfile = FileUtils.tempFileName(url, topicsDir, getSchemaAwareDirectory(TOPIC_PARTITION, schema1), extension);
+      fs.createNewFile(new Path(tempfile));
+      String committedFile = FileUtils.committedFileName(url, topicsDir, getSchemaAwareDirectory(TOPIC_PARTITION, schema1), TOPIC_PARTITION, startOffset,
+              endOffset, extension, zeroPadFormat);
+      wal.append(tempfile, committedFile);
     }
   }
 }

--- a/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
@@ -44,6 +44,7 @@ import io.confluent.connect.hdfs.partitioner.TimeUtils;
 import io.confluent.connect.storage.hive.HiveConfig;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
+import static io.confluent.connect.hdfs.HdfsSinkConnectorConfig.MULTI_SCHEMA_SUPPORT_CONFIG;
 import static org.junit.Assert.assertEquals;
 
 public class HiveIntegrationAvroTest extends HiveTestBase {
@@ -489,5 +490,60 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     records.add(record2);
     records.add(record3);
     return records.toArray(new Struct[records.size()]);
+  }
+
+  @Test
+  public void testHiveIntegrationAvroWitmMultipleSchemas() throws Exception {
+    localProps.put(HiveConfig.HIVE_INTEGRATION_CONFIG, "true");
+    localProps.put(MULTI_SCHEMA_SUPPORT_CONFIG, "true");
+    setUp();
+    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.recover(TOPIC_PARTITION);
+
+    String key = "key";
+    Schema[] schemas = new Schema[] {
+            createSchema(),
+            createSchema("record2"),
+    };
+    Struct[] records = new Struct[] {
+            createRecord(schemas[0]),
+            createRecord(schemas[1])
+    };
+
+
+    Collection<SinkRecord> sinkRecords1 = new ArrayList<>();
+    Collection<SinkRecord> sinkRecords2 = new ArrayList<>();
+    for (int offset = 0; offset < 14; offset++) {
+      Schema schema = schemas[offset % schemas.length];
+      Struct record = records[offset % schemas.length];
+      sinkRecords1.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset));
+    }
+
+    hdfsWriter.write(sinkRecords1);
+    hdfsWriter.write(sinkRecords2);
+    hdfsWriter.close();
+    hdfsWriter.stop();
+
+    for (Schema schema : schemas) {
+      Table table = hiveMetaStore.getTable(hiveDatabase, schema.name());
+      List<String> expectedColumnNames = new ArrayList<>();
+      for (Field field : schema.fields()) {
+        expectedColumnNames.add(field.name());
+      }
+
+      List<String> actualColumnNames = new ArrayList<>();
+      for (FieldSchema column : table.getSd().getCols()) {
+        actualColumnNames.add(column.getName());
+      }
+      assertEquals(expectedColumnNames, actualColumnNames);
+
+      List<String> expectedPartitions = new ArrayList<>();
+      String directory = TOPIC + "/" + schema.name() + "/" + "partition=" + String.valueOf(PARTITION);
+      expectedPartitions.add(FileUtils.directoryName(url, topicsDir, directory));
+
+      List<String> partitions = hiveMetaStore.listPartitions(hiveDatabase, schema.name(), (short) -1);
+
+      assertEquals(expectedPartitions, partitions);
+    }
   }
 }

--- a/src/test/java/io/confluent/connect/hdfs/partitioner/SchemaAwarePartitionerDecoratorTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/partitioner/SchemaAwarePartitionerDecoratorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.partitioner;
+
+import io.confluent.connect.hdfs.HdfsSinkConnectorTestBase;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
+import static org.junit.Assert.assertEquals;
+
+public class SchemaAwarePartitionerDecoratorTest extends HdfsSinkConnectorTestBase {
+
+  @Test
+  public void testGeneratePartitionedPath() throws Exception {
+    setUp();
+    SchemaAwarePartitionerDecorator partitioner = new SchemaAwarePartitionerDecorator(new InternalPartitioner());
+    partitioner.configure(parsedConfig);
+    Schema schema = createSchema();
+    SinkRecord record = new SinkRecord(TOPIC, 0, STRING_SCHEMA, "key", schema, createRecord(schema, 16, 12), 0);
+    String paritionEncoded = partitioner.encodePartition(record);
+    assertEquals(schema.name() + "/time=TEST", paritionEncoded);
+  }
+
+  private static class InternalPartitioner extends TimeBasedPartitioner {
+
+    @Override
+    public String encodePartition(SinkRecord sinkRecord) {
+      return "time=TEST";
+    }
+  }
+}

--- a/src/test/java/io/confluent/connect/hdfs/partitioner/TimeUtils.java
+++ b/src/test/java/io/confluent/connect/hdfs/partitioner/TimeUtils.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.hdfs.partitioner;
 
+import org.apache.kafka.connect.data.Schema;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -34,5 +35,10 @@ public class TimeUtils {
     long adjustedTimeStamp = timeZone.convertUTCToLocal(timestamp);
     long partitionedTime = (adjustedTimeStamp / timeGranularityMs) * timeGranularityMs;
     return timeZone.convertLocalToUTC(partitionedTime, false);
+  }
+
+  public static String encodeSchemaAwareTimestamp(Schema schema, long partitionDurationMs, String pathFormat, String timeZoneString, long timestamp) {
+    String timestampEncoding = encodeTimestamp(partitionDurationMs, pathFormat, timeZoneString, timestamp);
+    return schema.name() + "/" + timestampEncoding;
   }
 }


### PR DESCRIPTION
I would like to handle multiple schema types while keeping compatibility and hive integration turned on. Kafka connect supports it by 'value.subject.name.strategy' property. HDFS sink should be able to write records to different files basing on schema name and create separate hive tables for them.