### PR TITLE
MINOR: Correct checkstyle suppression line number for constructor

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -45,7 +45,7 @@
     <suppress
             checks="ParameterNumber"
             files="(TopicPartitionWriter).java"
-            lines="112,148"
+            lines="149"
     />
 
     <suppress


### PR DESCRIPTION
Caused by adding an extra line in #414, which shifted the constructor line number by one and making the suppression rule miss the constructor.