### PR TITLE
CC-3950: Change the HDFS sink task to return to Connect offsets for records committed to HDFS

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -45,7 +45,6 @@
     <suppress
             checks="ParameterNumber"
             files="(TopicPartitionWriter).java"
-            lines="112,148"
     />
 
     <suppress

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -504,7 +504,10 @@ public class DataWriter {
 
   public Map<TopicPartition, Long> getCommittedOffsets() {
     for (TopicPartition tp : assignment) {
-      offsets.put(tp, topicPartitionWriters.get(tp).offset());
+      Long committedOffset = topicPartitionWriters.get(tp).committedOffset();
+      if (committedOffset != null) {
+        offsets.put(tp, committedOffset);
+      }
     }
     return offsets;
   }

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -503,8 +503,10 @@ public class DataWriter {
   }
 
   public Map<TopicPartition, Long> getCommittedOffsets() {
+    log.debug("Writer looking for last offsets for topic partitions {}", assignment);
     for (TopicPartition tp : assignment) {
       Long committedOffset = topicPartitionWriters.get(tp).committedOffset();
+      log.debug("Writer found last offset {} for topic partition {}", committedOffset, tp);
       if (committedOffset != null) {
         offsets.put(tp, committedOffset);
       }

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -95,7 +95,8 @@ public class HdfsSinkTask extends SinkTask {
       }
     }
 
-    log.info("HDFS connector does not commit consumer offsets to Kafka. Upon startup, HDFS "
+    log.info("The connector relies on offsets in HDFS filenames, but does commit these offsets to "
+        + "Connect to enable monitoring progress of the HDFS connector. Upon startup, the HDFS "
         + "Connector restores offsets from filenames in HDFS. In the absence of files in HDFS, "
         + "the connector will attempt to find offsets for its consumer group in the "
         + "'__consumer_offsets' topic. If offsets are not found, the consumer will "
@@ -124,15 +125,15 @@ public class HdfsSinkTask extends SinkTask {
     // committed to HDFS.
     Map<TopicPartition, OffsetAndMetadata> result = new HashMap<>();
     for (Map.Entry<TopicPartition, Long> entry : hdfsWriter.getCommittedOffsets().entrySet()) {
+      log.debug(
+          "Found last committed offset {} for topic partition {}",
+          entry.getValue(),
+          entry.getKey()
+      );
       result.put(entry.getKey(), new OffsetAndMetadata(entry.getValue()));
     }
     log.debug("Returning committed offsets {}", result);
     return result;
-  }
-
-  @Override
-  public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
-    // Do nothing as the connector manages the offset and overrides 'preCommit()'
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -742,6 +742,7 @@ public class TopicPartitionWriter {
   }
 
   private void commitFile() {
+    log.debug("Committing files");
     appended.clear();
     for (String encodedPartition : tempFiles.keySet()) {
       commitFile(encodedPartition);
@@ -749,6 +750,7 @@ public class TopicPartitionWriter {
   }
 
   private void commitFile(String encodedPartition) {
+    log.debug("Committing file for partition {}", encodedPartition);
     if (!startOffsets.containsKey(encodedPartition)) {
       return;
     }
@@ -775,7 +777,7 @@ public class TopicPartitionWriter {
     startOffsets.remove(encodedPartition);
     offsets.remove(encodedPartition);
     offset = offset + recordCounter; // offset of next record to be reading
-    committedOffset = endOffset; // offset of last record written to HDFS
+    committedOffset = offset - 1; // offset of last record written to HDFS
     recordCounter = 0;
     log.info("Committed {} for {}", committedFile, tp);
   }

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -391,7 +391,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedOffsets();
     assertTrue(committedOffsets.containsKey(TOPIC_PARTITION));
     long previousOffset = committedOffsets.get(TOPIC_PARTITION);
-    assertEquals(NUMBER_OF_RECORDS-1, previousOffset);
+    assertEquals(NUMBER_OF_RECORDS - 1, previousOffset);
 
     hdfsWriter.close();
     hdfsWriter.stop();

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -190,7 +190,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
 
     assertTrue(committedOffsets.containsKey(TOPIC_PARTITION));
     long previousOffset = committedOffsets.get(TOPIC_PARTITION);
-    assertEquals(previousOffset, 6L);
+    assertEquals(previousOffset, 6L - 1);
 
     hdfsWriter.close();
     hdfsWriter.stop();
@@ -391,7 +391,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedOffsets();
     assertTrue(committedOffsets.containsKey(TOPIC_PARTITION));
     long previousOffset = committedOffsets.get(TOPIC_PARTITION);
-    assertEquals(NUMBER_OF_RECORDS, previousOffset);
+    assertEquals(NUMBER_OF_RECORDS-1, previousOffset);
 
     hdfsWriter.close();
     hdfsWriter.stop();

--- a/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
@@ -59,6 +59,7 @@ import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
 import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
@@ -186,9 +187,14 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
       topicPartitionWriter.buffer(record);
     }
 
+    assertNull(topicPartitionWriter.committedOffset());
+
     topicPartitionWriter.recover();
+    assertNull(topicPartitionWriter.committedOffset());
     topicPartitionWriter.write();
+    assertEquals(8, topicPartitionWriter.committedOffset().longValue());
     topicPartitionWriter.close();
+    assertEquals(8, topicPartitionWriter.committedOffset().longValue());
 
     String directory1 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(16));
     String directory2 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(17));
@@ -201,6 +207,10 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
 
     int expectedBatchSize = 3;
     verify(expectedFiles, expectedBatchSize, records, schema);
+
+    // Try recovering at this point, and check that we've not lost our committed offsets
+    topicPartitionWriter.recover();
+    assertEquals(8, topicPartitionWriter.committedOffset().longValue());
   }
 
   @Test

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,12 @@
+log4j.rootLogger=ERROR, stdout
+#log4j.rootLogger=INFO, stdout
+
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.I0Itec.zkclient=ERROR
+log4j.logger.org.reflections=ERROR
+#log4j.logger.io.confluent.connect.hdfs=DEBUG


### PR DESCRIPTION
Modified the task’s `preCommit(…)` method to always return the offsets for only those records that have been committed to HDFS. Connect will then use the consumer to commit those offsets to the `__consumer_offsets` topic, which allows for simple monitoring of the approximate lag of the connector.

First, this change does not affect the HDFS connector’s exactly once behavior, because the connector still writes and uses the offsets it records in the files in HDFS; as long as these files are found in HDFS for the topic partitions, the HDFS connector will use these to determine where Connect should begin consuming. If the HDFS connector does not find the files in HDFS, it will let Connect and the consumer determine where to start, which will be based upon the committed offsets if found or upon the `consumer.auto.offset.reset` value specified in the worker config (which for Connect defaults to `earliest`) if no offsets are found. None of this behavior has changed.

What has changed is that, starting with CP 4.0.1, the HDFS sink connector never returned offsets, which means Connect never updating the offsets in `__consumer_offsets` for the topic partitions the connector read. Users could still change these offsets, and the connector would use these if no offsets were found in HDFS, but it never updated these offsets.

Now, the HDFS connector does return the offsets of the records from the various topic partitions that were most recently committed to HDFS, and Connect will thus periodically (based upon `consumer.offset.flush.interval.ms` in the worker config) write these offsets to the `__consumer_offsets` topic using the appropriate consumer group for the connector.

Because the offsets are committed to `__consumer_offsets` asynchronously, it is likely that the offsets in `__consumer_offsets` will be somewhat behind where the connector actually is. In fact, the offsets in `__consumer_offsets` should never be ahead of the records that the connector has written to HDFS. This allows the offsets as a simple way to estimate the upper limit of the actual connector lag.