### PR TITLE
CC-4124:  Clear partition assignment on close

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -458,10 +458,9 @@ public class DataWriter {
         topicPartitionWriters.get(tp).close();
       } catch (ConnectException e) {
         log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
-      } finally {
-        topicPartitionWriters.remove(tp);
       }
     }
+    topicPartitionWriters.clear();
     assignment.clear();
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -462,6 +462,7 @@ public class DataWriter {
         topicPartitionWriters.remove(tp);
       }
     }
+    assignment.clear();
   }
 
   public void stop() {


### PR DESCRIPTION
When the HDFS Sink task is closed, it does not clear its partition assignment (something that the S3 Sink task does). This can cause an NPE since during `close` it clears the `topicPartitionWriters` but not the `assignment` that is used to iterate over `topicPartitionWriters`.