### PR TITLE
Add compression support to the StringFormat

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -114,6 +114,18 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
   private static final String KERBEROS_TICKET_RENEW_PERIOD_MS_DISPLAY = "Kerberos Ticket Renew "
       + "Period (ms)";
 
+  // Compression group
+  public static final String STRING_FORMAT_COMPRESSION_CONFIG = "format.string.compression";
+  public static final String STRING_FORMAT_COMPRESSION_NONE = "none";
+  public static final String STRING_FORMAT_COMPRESSION_DEFAULT = STRING_FORMAT_COMPRESSION_NONE;
+  public static final String STRING_FORMAT_COMPRESSION_DOC =
+      "Compression codec to use with StringFormat output. "
+          + "Use 'none' for uncompressed output. Available codecs depend on your HDFS setup, "
+          + "see org.apache.hadoop.io.compress.CompressionCodecFactory.getCodecByName "
+          + "for the full format description. Typically the 'deflate', 'gzip', and 'bzip2' codecs "
+          + "should be available.";
+  public static final String STRING_FORMAT_COMPRESSION_DISPLAY = "StringFormat's compression codec";
+
   private static final ConfigDef.Recommender hdfsAuthenticationKerberosDependentsRecommender =
       new BooleanParentRecommender(
           HDFS_AUTHENTICATION_KERBEROS_CONFIG);
@@ -276,6 +288,9 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
           hdfsAuthenticationKerberosDependentsRecommender
       );
     }
+
+    defineCompresionGroup(configDef);
+
     // Put the storage group(s) last ...
     ConfigDef storageConfigDef = StorageSinkConnectorConfig.newConfigDef(
         FORMAT_CLASS_RECOMMENDER,
@@ -285,6 +300,22 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
       configDef.define(key);
     }
     return configDef;
+  }
+
+  private static void defineCompresionGroup(ConfigDef configDef) {
+    final String group = "Compression";
+    // Compression for StringFormat
+    configDef.define(
+        STRING_FORMAT_COMPRESSION_CONFIG,
+        Type.STRING,
+        STRING_FORMAT_COMPRESSION_DEFAULT,
+        Importance.LOW,
+        STRING_FORMAT_COMPRESSION_DOC,
+        group,
+        0,
+        Width.NONE,
+        STRING_FORMAT_COMPRESSION_DISPLAY
+    );
   }
 
   private final String name;

--- a/src/main/java/io/confluent/connect/hdfs/string/StringRecordWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/string/StringRecordWriter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.string;
+
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.storage.format.RecordWriter;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.io.compress.CodecPool;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.Compressor;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+public class StringRecordWriter implements RecordWriter {
+  private static final int WRITER_BUFFER_SIZE = 128 * 1024;
+  private static final Logger log = LoggerFactory.getLogger(StringRecordWriterProvider.class);
+  private BufferedWriter writer;
+  private Compressor compressor;
+
+  @SuppressWarnings("WeakerAccess")
+  public StringRecordWriter(HdfsSinkConnectorConfig conf,
+                            String filename,
+                            CompressionCodec compressionCodec) throws IOException {
+    final Path path = new Path(filename);
+    OutputStream out = path.getFileSystem(conf.getHadoopConfiguration()).create(path);
+    if (compressionCodec != null) {
+      compressor = CodecPool.getCompressor(compressionCodec);
+      try {
+        out = compressionCodec.createOutputStream(out, compressor);
+      } catch (IOException e) {
+        CodecPool.returnCompressor(compressor);
+        IOUtils.closeStream(out);
+        throw e;
+      }
+    }
+    final OutputStreamWriter streamWriter = new OutputStreamWriter(out, Charset.defaultCharset());
+    writer = new BufferedWriter(streamWriter, WRITER_BUFFER_SIZE);
+  }
+
+  @Override
+  public void write(SinkRecord record) {
+    log.trace("Sink record: {}", record.toString());
+    try {
+      String value = (String) record.value();
+      writer.write(value);
+      writer.newLine();
+    } catch (IOException e) {
+      throw new ConnectException(e);
+    }
+  }
+
+  @Override
+  public void commit() {}
+
+  @Override
+  public void close() {
+    try {
+      writer.close();
+    } catch (IOException e) {
+      throw new ConnectException(e);
+    } finally {
+      if (compressor != null) {
+        CodecPool.returnCompressor(compressor);
+        compressor = null;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change enables the use of `CompressionCodec`s installed in Hadoop with the `StringFormat` of HDFS Connector. It introduces a new config parameter - `format.string.compression`, with a default value of "none", so by default it behaves in the same way as before.