### PR TITLE
CC-4318 Fix off-by-one error for offset reporting to Kafka topic

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -504,12 +504,14 @@ public class DataWriter {
    * By convention, the consumer stores the offset that corresponds to the next record to consume.
    * To follow this convention, this methods returns each offset that is one more than the last
    * offset committed to HDFS.
+   *
+   * @return Map from TopicPartition to next offset after the most recently committd offset to HDFS
    */
-  public Map<TopicPartition, Long> getCommittedConsumerOffsets() {
+  public Map<TopicPartition, Long> getCommittedOffsets() {
     Map<TopicPartition, Long> offsets = new HashMap<>();
     log.debug("Writer looking for last offsets for topic partitions {}", assignment);
     for (TopicPartition tp : assignment) {
-      long committedOffset = topicPartitionWriters.get(tp).committedConsumerOffset();
+      long committedOffset = topicPartitionWriters.get(tp).offset();
       log.debug("Writer found last offset {} for topic partition {}", committedOffset, tp);
       if (committedOffset >= 0) {
         offsets.put(tp, committedOffset);

--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -140,7 +140,7 @@ public class FileUtils {
   }
 
   /**
-   * Returns the last offset written in a file to HDFS.
+   * @return The last offset written in a file to HDFS.
    */
   public static long extractOffset(String filename) {
     Matcher m = HdfsSinkConnectorConstants.COMMITTED_FILENAME_PATTERN.matcher(filename);

--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -140,7 +140,10 @@ public class FileUtils {
   }
 
   /**
-   * @return The last offset written in a file to HDFS.
+   * Obtain the offset of the last record that was written to the specified HDFS file.
+   * @param filename the name of the HDFS file; may not be null
+   * @return the offset of the last record written to the specified file in HDFS
+   * @throws IllegalArgumentException if the filename does not match the expected pattern
    */
   public static long extractOffset(String filename) {
     Matcher m = HdfsSinkConnectorConstants.COMMITTED_FILENAME_PATTERN.matcher(filename);

--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -139,6 +139,9 @@ public class FileUtils {
     return fileStatusWithMaxOffset;
   }
 
+  /**
+   * Returns the last offset written in a file to HDFS.
+   */
   public static long extractOffset(String filename) {
     Matcher m = HdfsSinkConnectorConstants.COMMITTED_FILENAME_PATTERN.matcher(filename);
     // NB: if statement has side effect of enabling group() call

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -124,8 +124,7 @@ public class HdfsSinkTask extends SinkTask {
     // commit the consumer offsets for records this task has consumed from its topic partitions and
     // committed to HDFS.
     Map<TopicPartition, OffsetAndMetadata> result = new HashMap<>();
-    for (Map.Entry<TopicPartition, Long> entry :
-        hdfsWriter.getCommittedConsumerOffsets().entrySet()) {
+    for (Map.Entry<TopicPartition, Long> entry : hdfsWriter.getCommittedOffsets().entrySet()) {
       log.debug(
           "Found last committed offset {} for topic partition {}",
           entry.getValue(),

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -124,7 +124,8 @@ public class HdfsSinkTask extends SinkTask {
     // commit the consumer offsets for records this task has consumed from its topic partitions and
     // committed to HDFS.
     Map<TopicPartition, OffsetAndMetadata> result = new HashMap<>();
-    for (Map.Entry<TopicPartition, Long> entry : hdfsWriter.getCommittedOffsets().entrySet()) {
+    for (Map.Entry<TopicPartition, Long> entry :
+        hdfsWriter.getCommittedConsumerOffsets().entrySet()) {
       log.debug(
           "Found last committed offset {} for topic partition {}",
           entry.getValue(),

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -487,7 +487,8 @@ public class TopicPartitionWriter {
    * This method returns the next offset after the last one in HDFS, useful for some APIs
    * (like Kafka Consumer offset tracking).
    *
-   * @return Next offset after the last offset written to HDFS
+   * @return Next offset after the last offset written to HDFS, or -1 if no file has been committed
+   * yet
    */
   public long offset() {
     return offset;

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -488,7 +488,7 @@ public class TopicPartitionWriter {
    * (like Kafka Consumer offset tracking).
    *
    * @return Next offset after the last offset written to HDFS, or -1 if no file has been committed
-   * yet
+   *     yet
    */
   public long offset() {
     return offset;

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -333,8 +333,7 @@ public class TopicPartitionWriter {
             nextState();
           case WRITE_PARTITION_PAUSED:
             if (currentSchema == null) {
-              if (compatibility != StorageSchemaCompatibility.NONE
-                  && offset != -1) {
+              if (compatibility != StorageSchemaCompatibility.NONE && offset != -1) {
                 String topicDir = FileUtils.topicDirectory(url, topicsDir, tp.topic());
                 CommittedFileFilter filter = new TopicPartitionCommittedFileFilter(tp);
                 FileStatus fileStatusWithMaxOffset = FileUtils.fileStatusWithMaxOffset(

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -185,7 +185,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
     hdfsWriter.recover(TOPIC_PARTITION);
 
-    Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedConsumerOffsets();
+    Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedOffsets();
 
     assertTrue(committedOffsets.containsKey(TOPIC_PARTITION));
     long nextOffset = committedOffsets.get(TOPIC_PARTITION);
@@ -387,7 +387,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     time.sleep(WAIT_TIME);
     hdfsWriter.write(new ArrayList<SinkRecord>());
 
-    Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedConsumerOffsets();
+    Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedOffsets();
     assertTrue(committedOffsets.containsKey(TOPIC_PARTITION));
     long nextOffset = committedOffsets.get(TOPIC_PARTITION);
     assertEquals(NUMBER_OF_RECORDS, nextOffset);

--- a/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
@@ -188,16 +188,16 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
       topicPartitionWriter.buffer(record);
     }
 
-    assertEquals(-1, topicPartitionWriter.committedConsumerOffset());
+    assertEquals(-1, topicPartitionWriter.offset());
 
     topicPartitionWriter.recover();
-    assertEquals(-1, topicPartitionWriter.committedConsumerOffset());
+    assertEquals(-1, topicPartitionWriter.offset());
     topicPartitionWriter.write();
     // Flush size is 3, so records with offset 0-8 inclusive are written, and 9 is the next one
     // after the last committed
-    assertEquals(9, topicPartitionWriter.committedConsumerOffset());
+    assertEquals(9, topicPartitionWriter.offset());
     topicPartitionWriter.close();
-    assertEquals(9, topicPartitionWriter.committedConsumerOffset());
+    assertEquals(9, topicPartitionWriter.offset());
 
     String directory1 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(16));
     String directory2 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(17));
@@ -213,7 +213,7 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
 
     // Try recovering at this point, and check that we've not lost our committed offsets
     topicPartitionWriter.recover();
-    assertEquals(9, topicPartitionWriter.committedConsumerOffset());
+    assertEquals(9, topicPartitionWriter.offset());
   }
 
   @Test


### PR DESCRIPTION
Consumer groups were reporting current-offset as one less than
log-end-offset in the fully caught-up state.

This fixes the topic's perception of current offset to match
the current offset we are storing in HDFS