### PR TITLE
CC-4350 WIP: Bypass HDFS FileSystem Cache

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
@@ -92,12 +92,23 @@ public class AvroRecordWriterProvider
 
       @Override
       public void close() {
+        IOException error = null;
         try {
           writer.close();
           // Must be closed independently to prevent resource leaks
-          fs.close();
         } catch (IOException e) {
+          error = e;
           throw new DataException(e);
+        } finally {
+          if (fs != null) {
+            try {
+              fs.close();
+            } catch (IOException e) {
+              if (error == null) {
+                throw new DataException(e);
+              }
+            }
+          }
         }
       }
 

--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
@@ -18,6 +18,7 @@ import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -63,7 +64,8 @@ public class AvroRecordWriterProvider
           schema = record.valueSchema();
           try {
             log.info("Opening record writer for: {}", filename);
-            final FSDataOutputStream out = path.getFileSystem(conf.getHadoopConfiguration())
+            final FSDataOutputStream out = FileSystem.newInstance(path.toUri(),
+                conf.getHadoopConfiguration())
                 .create(path);
             org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
             writer.setCodec(CodecFactory.fromString(conf.getAvroCodec()));

--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
@@ -54,6 +54,7 @@ public class AvroRecordWriterProvider
       final String filename
   ) {
     return new io.confluent.connect.storage.format.RecordWriter() {
+      FSDataOutputStream out;
       final DataFileWriter<Object> writer = new DataFileWriter<>(new GenericDatumWriter<>());
       final Path path = new Path(filename);
       Schema schema = null;
@@ -64,7 +65,7 @@ public class AvroRecordWriterProvider
           schema = record.valueSchema();
           try {
             log.info("Opening record writer for: {}", filename);
-            final FSDataOutputStream out = FileSystem.newInstance(path.toUri(),
+            out = FileSystem.newInstance(path.toUri(),
                 conf.getHadoopConfiguration())
                 .create(path);
             org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
@@ -94,6 +95,7 @@ public class AvroRecordWriterProvider
       public void close() {
         try {
           writer.close();
+          out.close();
         } catch (IOException e) {
           throw new DataException(e);
         }

--- a/src/main/java/io/confluent/connect/hdfs/json/JsonRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/json/JsonRecordWriterProvider.java
@@ -103,11 +103,20 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<HdfsSinkCo
 
         @Override
         public void close() {
+          IOException error = null;
           try {
             writer.close();
-            fs.close();
           } catch (IOException e) {
+            error = e;
             throw new ConnectException(e);
+          } finally {
+            try {
+              fs.close();
+            } catch (IOException e) {
+              if (error == null) {
+                throw new ConnectException(e);
+              }
+            }
           }
         }
       };

--- a/src/main/java/io/confluent/connect/hdfs/json/JsonRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/json/JsonRecordWriterProvider.java
@@ -105,6 +105,7 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<HdfsSinkCo
         public void close() {
           try {
             writer.close();
+            out.close();
           } catch (IOException e) {
             throw new ConnectException(e);
           }

--- a/src/main/java/io/confluent/connect/hdfs/json/JsonRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/json/JsonRecordWriterProvider.java
@@ -70,8 +70,8 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<HdfsSinkCo
     try {
       return new RecordWriter() {
         final Path path = new Path(filename);
-        final OutputStream out = FileSystem.newInstance(path.toUri(),
-            conf.getHadoopConfiguration()).create(path);
+        final FileSystem fs = FileSystem.newInstance(path.toUri(), conf.getHadoopConfiguration());
+        final OutputStream out = fs.create(path);
         final JsonGenerator writer = mapper.getFactory()
             .createGenerator(out)
             .setRootValueSeparator(null);
@@ -105,7 +105,7 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<HdfsSinkCo
         public void close() {
           try {
             writer.close();
-            out.close();
+            fs.close();
           } catch (IOException e) {
             throw new ConnectException(e);
           }

--- a/src/main/java/io/confluent/connect/hdfs/json/JsonRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/json/JsonRecordWriterProvider.java
@@ -16,6 +16,7 @@ package io.confluent.connect.hdfs.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -69,7 +70,8 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<HdfsSinkCo
     try {
       return new RecordWriter() {
         final Path path = new Path(filename);
-        final OutputStream out = path.getFileSystem(conf.getHadoopConfiguration()).create(path);
+        final OutputStream out = FileSystem.newInstance(path.toUri(),
+            conf.getHadoopConfiguration()).create(path);
         final JsonGenerator writer = mapper.getFactory()
             .createGenerator(out)
             .setRootValueSeparator(null);

--- a/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
+++ b/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
@@ -95,7 +95,7 @@ public class HdfsStorage
   public OutputStream create(String filename, HdfsSinkConnectorConfig conf, boolean overwrite) {
     try {
       Path path = new Path(filename);
-      return path.getFileSystem(conf.getHadoopConfiguration()).create(path);
+      return FileSystem.newInstance(path.toUri(), conf.getHadoopConfiguration()).create(path);
     } catch (IOException e) {
       throw new ConnectException(e);
     }

--- a/src/main/java/io/confluent/connect/hdfs/string/StringRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/string/StringRecordWriterProvider.java
@@ -61,8 +61,8 @@ public class StringRecordWriterProvider implements RecordWriterProvider<HdfsSink
     try {
       return new RecordWriter() {
         final Path path = new Path(filename);
-        final OutputStream out =
-            FileSystem.newInstance(path.toUri(), conf.getHadoopConfiguration()).create(path);
+        FileSystem fs = FileSystem.newInstance(path.toUri(), conf.getHadoopConfiguration());
+        final OutputStream out = fs.create(path);
         final OutputStreamWriter streamWriter = new OutputStreamWriter(
             out,
             Charset.defaultCharset()
@@ -88,7 +88,7 @@ public class StringRecordWriterProvider implements RecordWriterProvider<HdfsSink
         public void close() {
           try {
             writer.close();
-            out.close();
+            fs.close();
           } catch (IOException e) {
             throw new ConnectException(e);
           }

--- a/src/main/java/io/confluent/connect/hdfs/string/StringRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/string/StringRecordWriterProvider.java
@@ -88,6 +88,7 @@ public class StringRecordWriterProvider implements RecordWriterProvider<HdfsSink
         public void close() {
           try {
             writer.close();
+            out.close();
           } catch (IOException e) {
             throw new ConnectException(e);
           }

--- a/src/main/java/io/confluent/connect/hdfs/string/StringRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/string/StringRecordWriterProvider.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.hdfs.string;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -60,7 +61,8 @@ public class StringRecordWriterProvider implements RecordWriterProvider<HdfsSink
     try {
       return new RecordWriter() {
         final Path path = new Path(filename);
-        final OutputStream out = path.getFileSystem(conf.getHadoopConfiguration()).create(path);
+        final OutputStream out =
+            FileSystem.newInstance(path.toUri(), conf.getHadoopConfiguration()).create(path);
         final OutputStreamWriter streamWriter = new OutputStreamWriter(
             out,
             Charset.defaultCharset()

--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -142,7 +142,7 @@ public class WALFile {
       try {
         if (ownStream) {
           Path p = fileOption.getValue();
-          fs = p.getFileSystem(conf);
+          fs = FileSystem.newInstance(p.toUri(), conf);
           int bufferSize = bufferSizeOption == null
                            ? getBufferSize(conf)
                            : bufferSizeOption.getValue();
@@ -445,7 +445,7 @@ public class WALFile {
       try {
         if (fileOpt != null) {
           filename = fileOpt.getValue();
-          fs = filename.getFileSystem(conf);
+          fs = FileSystem.newInstance(filename.toUri(), conf);
           int bufSize = bufOpt == null ? getBufferSize(conf) : bufOpt.getValue();
           len = null == lenOpt
                 ? fs.getFileStatus(filename).getLen()

--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -321,6 +321,9 @@ public class WALFile {
         }
         out = null;
       }
+      if (fs != null) {
+        fs.close();
+      }
     }
 
     @Override
@@ -653,7 +656,9 @@ public class WALFile {
 
       // Close the input-stream
       in.close();
-      fs.close();
+      if (fs != null) {
+        fs.close();
+      }
     }
 
     private byte getVersion() {

--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -96,6 +96,7 @@ public class WALFile {
     private FSDataOutputStream out;
     private DataOutputBuffer buffer = new DataOutputBuffer();
     private boolean appendMode;
+    private FileSystem fs = null;
 
     {
       try {
@@ -135,7 +136,6 @@ public class WALFile {
         throw new IllegalArgumentException("file modifier options not compatible with stream");
       }
 
-      FileSystem fs = null;
       FSDataOutputStream out;
       boolean ownStream = fileOption != null;
 
@@ -419,6 +419,7 @@ public class WALFile {
     private DataInputStream valIn = null;
     private Deserializer<WALEntry> keyDeserializer;
     private Deserializer<WALEntry> valDeserializer;
+    private FileSystem fs = null;
 
     public Reader(Configuration conf, Option... opts) throws IOException {
       // Look up the options, these are null if not set
@@ -440,7 +441,7 @@ public class WALFile {
       Path filename = null;
       FSDataInputStream file;
       final long len;
-      FileSystem fs = null;
+
 
       try {
         if (fileOpt != null) {
@@ -652,6 +653,7 @@ public class WALFile {
 
       // Close the input-stream
       in.close();
+      fs.close();
     }
 
     private byte getVersion() {


### PR DESCRIPTION
Since there are some issues with HDFS clearing caches, it is recommended to get a fresh FileSystem with "newInstance" instead of with "get" to bypass caches.

This is not ready to merge -- it is currently in field-testing, and will need more testing and performance evaluation before a full review/merge process

Quoting Cloudera support, there are 3 options:
```
Just don't close the FileSystem. Even if you don't close it
explicitly, it will be closed at process teardown via a shutdown hook.
This definitely looks wrong from a resource management perspective, but a
lot of applications work this way.

Call FileSystem#newInstance instead of FileSystem#get. The newInstance
method is guaranteed to return an instance unique to that call site, not a
shared instance potentially in use by other call sites. If you use
newInstance, then you must guarantee it gets closed to avoid a leak with a
long-term impact.

You can disable the FileSystem cache for specific file system types by
editing core-site.xml and setting property fs..impl.disable.cache to true, e.g. fs.hdfs.impl.disable.cache. In
general, disabling the cache is not desirable, because the performance
benefits of the cache are noticeable. Sometimes this is a helpful
workaround for specific applications though.
```