### PR TITLE
CC-4433b: Import Hive as separate package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
             <version>${confluent.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-hive</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -61,6 +61,7 @@ import io.confluent.connect.hdfs.storage.Storage;
 import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.format.SchemaFileReader;
 import io.confluent.connect.storage.hive.HiveConfig;
+import io.confluent.connect.storage.hive.HiveFactory;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
 public class DataWriter {
@@ -288,7 +289,8 @@ public class DataWriter {
           hive = format.getHiveUtil(connectorConfig, hiveMetaStore);
         } else if (newFormat != null) {
           final io.confluent.connect.storage.hive.HiveUtil newHiveUtil
-              = newFormat.getHiveFactory().createHiveUtil(connectorConfig, hiveMetaStore);
+              = ((HiveFactory) newFormat.getHiveFactory())
+              .createHiveUtil(connectorConfig, hiveMetaStore);
           hive = new HiveUtil(connectorConfig, hiveMetaStore) {
             @Override
             public void createTable(

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.confluent.connect.avro.AvroData;
+import io.confluent.connect.storage.StorageSinkConnectorConfig;
 import io.confluent.connect.storage.hive.HiveConfig;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import io.confluent.connect.storage.schema.StorageSchemaCompatibility;
@@ -56,7 +57,7 @@ public class HdfsSinkTask extends SinkTask {
       boolean hiveIntegration = connectorConfig.getBoolean(HiveConfig.HIVE_INTEGRATION_CONFIG);
       if (hiveIntegration) {
         StorageSchemaCompatibility compatibility = StorageSchemaCompatibility.getCompatibility(
-            connectorConfig.getString(HiveConfig.SCHEMA_COMPATIBILITY_CONFIG)
+            connectorConfig.getString(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG)
         );
         if (compatibility == StorageSchemaCompatibility.NONE) {
           throw new ConfigException(

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -52,6 +52,7 @@ import io.confluent.connect.hdfs.hive.HiveMetaStore;
 import io.confluent.connect.hdfs.hive.HiveUtil;
 import io.confluent.connect.hdfs.partitioner.Partitioner;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
+import io.confluent.connect.storage.StorageSinkConnectorConfig;
 import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.hive.HiveConfig;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
@@ -195,7 +196,7 @@ public class TopicPartitionWriter {
         .ROTATE_SCHEDULE_INTERVAL_MS_CONFIG);
     timeoutMs = connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG);
     compatibility = StorageSchemaCompatibility.getCompatibility(
-        connectorConfig.getString(HiveConfig.SCHEMA_COMPATIBILITY_CONFIG));
+        connectorConfig.getString(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG));
 
     String logsDir = connectorConfig.getString(HdfsSinkConnectorConfig.LOGS_DIR_CONFIG);
     wal = storage.wal(logsDir, tp);

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -40,6 +40,7 @@ import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.hdfs.wal.WAL;
+import io.confluent.connect.storage.StorageSinkConnectorConfig;
 import io.confluent.connect.storage.hive.HiveConfig;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
@@ -269,7 +270,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   public void testProjectBackWard() throws Exception {
     Map<String, String> props = createProps();
     props.put(HdfsSinkConnectorConfig.FLUSH_SIZE_CONFIG, "2");
-    props.put(HiveConfig.SCHEMA_COMPATIBILITY_CONFIG, "BACKWARD");
+    props.put(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "BACKWARD");
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
@@ -309,7 +310,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   public void testProjectForward() throws Exception {
     Map<String, String> props = createProps();
     props.put(HdfsSinkConnectorConfig.FLUSH_SIZE_CONFIG, "2");
-    props.put(HiveConfig.SCHEMA_COMPATIBILITY_CONFIG, "FORWARD");
+    props.put(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "FORWARD");
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
@@ -330,7 +331,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   @Test
   public void testProjectNoVersion() throws Exception {
     Map<String, String> props = createProps();
-    props.put(HiveConfig.SCHEMA_COMPATIBILITY_CONFIG, "BACKWARD");
+    props.put(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "BACKWARD");
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);


### PR DESCRIPTION

• After Hive dependencies are removed from kafka-connect-storage-common package, kafka-connect-storage-hive needs to be imported explicitly. 

• After the change in Format interface, we need to explicitly cast to HiveFactory here. 