### PR TITLE
CC-4877: Include storage-hive artifacts in the assembly

### DIFF
--- a/src/assembly/package.xml
+++ b/src/assembly/package.xml
@@ -45,7 +45,6 @@
                 <exclude>io.confluent:kafka-connect-storage-common</exclude>
                 <exclude>io.confluent:kafka-connect-storage-core</exclude>
                 <exclude>io.confluent:kafka-connect-storage-format</exclude>
-                <exclude>io.confluent:kafka-connect-storage-hive</exclude>
                 <exclude>io.confluent:kafka-connect-storage-partitioner</exclude>
                 <exclude>io.confluent:kafka-connect-storage-wal</exclude>
             </excludes>


### PR DESCRIPTION
This exclusion caused the ducker images to be built without including the new library. 

Signed-off-by: Arjun Satish <arjun@confluent.io>