### PR TITLE
CC-5969: Pass extra connector configs to the partitioner

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -352,6 +352,15 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     for (AbstractConfig config : allConfigs) {
       map.putAll(config.values());
     }
+    // Include any additional properties not defined by the ConfigDef
+    // that custom partitioners might need
+    Map<String, ?> originals = originals();
+    for (String originalKey : originals.keySet()) {
+      if (!map.containsKey(originalKey)) {
+        map.put(originalKey, originals.get(originalKey));
+      }
+    }
+
     return map;
   }
 

--- a/src/test/java/io/confluent/connect/hdfs/CustomPartitionerPropertiesTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/CustomPartitionerPropertiesTest.java
@@ -1,0 +1,70 @@
+package io.confluent.connect.hdfs;
+
+import java.util.Map;
+
+import io.confluent.connect.hdfs.avro.AvroDataFileReader;
+import io.confluent.connect.hdfs.hive.HiveTestBase;
+import io.confluent.connect.storage.partitioner.Partitioner;
+import io.confluent.connect.storage.partitioner.PartitionerConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test to ensure we can still instantiate & use the old-style HDFS-only interfaces instead of
+ * those from storage-common and use them with DataWriter
+ */
+public class CustomPartitionerPropertiesTest extends HiveTestBase {
+
+  /**
+   * Extend the deprecated {@link io.confluent.connect.hdfs.partitioner.DefaultPartitioner}
+   * so that the {@link DataWriter} doesn't wrap it.
+   */
+  public static final class CustomPartitioner
+      extends io.confluent.connect.hdfs.partitioner.DefaultPartitioner {
+
+    public static final String CUSTOM_PROPERTY = "custom.property";
+    public static final String EXPECTED_VALUE = "expectThis";
+
+    String customValue;
+
+    @Override
+    public void configure(Map<String, Object> config) {
+      super.configure(config);
+      this.customValue = (String) config.get(CUSTOM_PROPERTY);
+    }
+
+    public String customValue() {
+      return this.customValue;
+    }
+  }
+
+  @Override
+  protected Map<String, String> createProps() {
+    Map<String, String> props = super.createProps();
+    props.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, CustomPartitioner.class.getName());
+    props.put(CustomPartitioner.CUSTOM_PROPERTY, CustomPartitioner.EXPECTED_VALUE);
+    return props;
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    dataFileReader = new AvroDataFileReader();
+    extension = ".avro";
+  }
+
+  @Test
+  public void createDataWriterWithCustomPartitioner() {
+    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    Partitioner<?> partitioner = hdfsWriter.getPartitioner();
+    assertEquals(CustomPartitioner.class.getName(), partitioner.getClass().getName());
+    CustomPartitioner customPartitioner = (CustomPartitioner) partitioner;
+    assertEquals(CustomPartitioner.EXPECTED_VALUE, customPartitioner.customValue());
+
+    hdfsWriter.close();
+    hdfsWriter.stop();
+  }
+}


### PR DESCRIPTION
The HDFS connector currently passes all of its known connector properties to the partitioner, but extra properties not known to the connector are excluded. With this change, the connector will also pass any extra connector configuration properties to the partitioner.

Added a unit test to verify that a custom partitioner will see the extra properties. This new test failed before the `HdfsSinkConnectorConfig` code was changed, and now passes.