### PR TITLE
CC-6089: Improve fault tolerance of HDFS sink connector

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -455,7 +455,7 @@ public class DataWriter {
       try {
         TopicPartitionWriter writer = ent.getValue();
         if (writer != null) {
-          // In some failure modes, with might not have created a writer for all assignments
+          // In some failure modes, the writer might not have been created for all assignments
           writer.close();
         }
       } catch (ConnectException e) {

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -451,20 +451,14 @@ public class DataWriter {
     // data may have continued to be processed and we'd have to restart from the recovery stage,
     // make sure we apply the WAL, and only reuse the temp file if the starting offset is still
     // valid. For now, we prefer the simpler solution that may result in a bit of wasted effort.
-    for (Map.Entry<TopicPartition, TopicPartitionWriter> ent : topicPartitionWriters.entrySet()) {
+    for (TopicPartitionWriter writer : topicPartitionWriters.values()) {
       try {
-        TopicPartitionWriter writer = ent.getValue();
         if (writer != null) {
           // In some failure modes, the writer might not have been created for all assignments
           writer.close();
         }
       } catch (ConnectException e) {
-        log.warn(
-            "Unable to close writer for topic partition {}: {}",
-            ent.getKey(),
-            e.getMessage(),
-            e
-        );
+        log.warn("Unable to close writer for topic partition {}: ", writer.topicPartition(), e);
       }
     }
     topicPartitionWriters.clear();

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -87,12 +87,24 @@ public class HdfsSinkTask extends SinkTask {
     } catch (ConfigException e) {
       throw new ConnectException("Couldn't start HdfsSinkConnector due to configuration error.", e);
     } catch (ConnectException e) {
+      // Log at info level to help explain reason, but Connect logs the actual exception at ERROR
       log.info("Couldn't start HdfsSinkConnector:", e);
       log.info("Shutting down HdfsSinkConnector.");
       if (hdfsWriter != null) {
-        hdfsWriter.close();
-        hdfsWriter.stop();
+        try {
+          try {
+            log.debug("Closing data writer due to task start failure.");
+            hdfsWriter.close();
+          } finally {
+            log.debug("Stopping data writer due to task start failure.");
+            hdfsWriter.stop();
+          }
+        } catch (Throwable t) {
+          log.debug("Error closing and stopping data writer: {}", t.getMessage(), t);
+        }
       }
+      // Always throw the original exception that prevent us from starting
+      throw e;
     }
 
     log.info("The connector relies on offsets in HDFS filenames, but does commit these offsets to "

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -696,6 +696,14 @@ public class TopicPartitionWriter {
   }
 
   private void closeTempFile(String encodedPartition) {
+    // Here we remove the writer first, and then if non-null attempt to close it.
+    // This is the correct logic, because if `close()` throws an exception and fails, the task
+    // will catch this an ultimately retry writing the records in that topic partition.
+    // But to do so, we need to get a new `RecordWriter`, and `getWriter(...)` would only
+    // do that if there is no existing writer in the `writers` map.
+    // Plus, once a `writer.close()` method is called, per the `Closeable` contract we should
+    // not use it again. Therefore, it's actually better to remove the writer before
+    // trying to close it, even if the close attempt fails.
     io.confluent.connect.storage.format.RecordWriter writer = writers.remove(encodedPartition);
     if (writer != null) {
       writer.close();

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -692,15 +692,15 @@ public class TopicPartitionWriter {
   }
 
   private void closeTempFile(String encodedPartition) {
-    if (writers.containsKey(encodedPartition)) {
-      io.confluent.connect.storage.format.RecordWriter writer = writers.get(encodedPartition);
+    io.confluent.connect.storage.format.RecordWriter writer = writers.remove(encodedPartition);
+    if (writer != null) {
       writer.close();
-      writers.remove(encodedPartition);
     }
   }
 
   private void closeTempFile() {
     for (String encodedPartition : tempFiles.keySet()) {
+      // Close the file and propagate any errors
       closeTempFile(encodedPartition);
     }
   }

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -498,6 +498,10 @@ public class TopicPartitionWriter {
     return offset;
   }
 
+  public TopicPartition topicPartition() {
+    return tp;
+  }
+
   Map<String, io.confluent.connect.storage.format.RecordWriter> getWriters() {
     return writers;
   }


### PR DESCRIPTION
Changed the task to throw an exception if the task could not be started successfully. In some cases, an exception would be logged but not re-thrown.

Also checked for null references in a couple of places that can result from an improperly-started or failing task.