### PR TITLE
CC-6196: fix NPE for store.url config

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -203,7 +203,7 @@ public class DataWriter {
         ticketRenewThread.start();
       }
 
-      url = connectorConfig.getString(HdfsSinkConnectorConfig.HDFS_URL_CONFIG);
+      url = connectorConfig.getUrl();
       topicsDir = connectorConfig.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
 
       @SuppressWarnings("unchecked")

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.hdfs;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -302,11 +303,11 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     partitionerConfig = new PartitionerConfig(partitionerConfigDef, originalsStrings());
     this.name = parseName(originalsStrings());
     this.hadoopConfig = new Configuration();
-    this.url = extractUrl(props);
     addToGlobal(hiveConfig);
     addToGlobal(partitionerConfig);
     addToGlobal(commonConfig);
     addToGlobal(this);
+    this.url = extractUrl();
   }
 
   public static Map<String, String> addDefaults(Map<String, String> props) {
@@ -336,22 +337,21 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
    * Returns the url property. Preference is given to property <code>store.url</code> over
    * <code>hdfs.url</code> because <code>hdfs.url</code> is deprecated.
    *
-   * @param props - Map of properties for the connector
-   * @return String - url for HDFS
+   * @return String url for HDFS
    */
-  private String extractUrl(Map<String, String> props) {
-    String storageUrl = props.get(StorageCommonConfig.STORE_URL_CONFIG);
-    if (storageUrl != null && !storageUrl.equals(StorageCommonConfig.STORE_URL_DEFAULT)) {
+  private String extractUrl() {
+    String storageUrl = getString(StorageCommonConfig.STORE_URL_CONFIG);
+    if (StringUtils.isNotBlank(storageUrl)) {
       return storageUrl;
     }
 
-    String hdfsUrl = props.get(HDFS_URL_CONFIG);
-    if (hdfsUrl != null && !hdfsUrl.equals(HDFS_URL_DEFAULT)) {
+    String hdfsUrl = getString(HDFS_URL_CONFIG);
+    if (StringUtils.isNotBlank(hdfsUrl)) {
       return hdfsUrl;
     }
 
     throw new ConfigException(
-        String.format("Configuration %s cannot be empty."), StorageCommonConfig.STORE_URL_CONFIG
+        String.format("Configuration %s cannot be empty.", StorageCommonConfig.STORE_URL_CONFIG)
     );
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -332,7 +332,14 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     }
   }
 
-  private static String extractUrl(Map<String, String> props) {
+  /**
+   * Returns the url property. Preference is given to property `store.url` over `hdfs.url` because
+   * `hdfs.url` is deprecated.
+   *
+   * @param props - Map of properties for the connector
+   * @return String - url for HDFS
+   */
+  private String extractUrl(Map<String, String> props) {
     String storageUrl = props.get(StorageCommonConfig.STORE_URL_CONFIG);
     if (storageUrl != null && !storageUrl.equals(StorageCommonConfig.STORE_URL_DEFAULT)) {
       return storageUrl;

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -302,7 +302,7 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     partitionerConfig = new PartitionerConfig(partitionerConfigDef, originalsStrings());
     this.name = parseName(originalsStrings());
     this.hadoopConfig = new Configuration();
-    this.url = extractUrl(originalsStrings());
+    this.url = extractUrl(props);
     addToGlobal(hiveConfig);
     addToGlobal(partitionerConfig);
     addToGlobal(commonConfig);

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -333,8 +333,8 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
   }
 
   /**
-   * Returns the url property. Preference is given to property `store.url` over `hdfs.url` because
-   * `hdfs.url` is deprecated.
+   * Returns the url property. Preference is given to property <code>store.url</code> over
+   * <code>hdfs.url</code> because <code>hdfs.url</code> is deprecated.
    *
    * @param props - Map of properties for the connector
    * @return String - url for HDFS

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -281,6 +281,7 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
   }
 
   private final String name;
+  private final String url;
   private final StorageCommonConfig commonConfig;
   private final HiveConfig hiveConfig;
   private final PartitionerConfig partitionerConfig;
@@ -301,6 +302,7 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     partitionerConfig = new PartitionerConfig(partitionerConfigDef, originalsStrings());
     this.name = parseName(originalsStrings());
     this.hadoopConfig = new Configuration();
+    this.url = extractUrl(originalsStrings());
     addToGlobal(hiveConfig);
     addToGlobal(partitionerConfig);
     addToGlobal(commonConfig);
@@ -330,8 +332,28 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     }
   }
 
+  private static String extractUrl(Map<String, String> props) {
+    String storageUrl = props.get(StorageCommonConfig.STORE_URL_CONFIG);
+    if (storageUrl != null && !storageUrl.equals(StorageCommonConfig.STORE_URL_DEFAULT)) {
+      return storageUrl;
+    }
+
+    String hdfsUrl = props.get(HDFS_URL_CONFIG);
+    if (hdfsUrl != null && !hdfsUrl.equals(HDFS_URL_DEFAULT)) {
+      return hdfsUrl;
+    }
+
+    throw new ConfigException(
+        String.format("Configuration %s cannot be empty."), StorageCommonConfig.STORE_URL_CONFIG
+    );
+  }
+
   public String getName() {
     return name;
+  }
+
+  public String getUrl() {
+    return url;
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/hive/HiveUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/HiveUtil.java
@@ -19,7 +19,6 @@ import org.apache.kafka.connect.data.Schema;
 
 import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import io.confluent.connect.hdfs.partitioner.Partitioner;
-import io.confluent.connect.storage.common.StorageCommonConfig;
 
 // NOTE: DO NOT add or modify this class as it is maintained for compatibility
 @Deprecated
@@ -27,14 +26,7 @@ public abstract class HiveUtil extends io.confluent.connect.storage.hive.HiveUti
 
   public HiveUtil(HdfsSinkConnectorConfig connectorConfig, HiveMetaStore hiveMetaStore) {
     super(connectorConfig, hiveMetaStore);
-    String urlKey;
-
-    urlKey = connectorConfig.getString(StorageCommonConfig.STORE_URL_CONFIG);
-    if (urlKey == null || urlKey.equals(StorageCommonConfig.STORE_URL_DEFAULT)) {
-      urlKey = connectorConfig.getString(HdfsSinkConnectorConfig.HDFS_URL_CONFIG);
-    }
-
-    this.url = urlKey;
+    this.url = connectorConfig.getUrl();
   }
 
   @Override

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
@@ -65,6 +65,13 @@ public class HdfsSinkConnectorConfigTest extends TestWithMiniDFSCluster {
   }
 
   @Test
+  public void testHdfsUrlIsValid() {
+    connectorConfig = new HdfsSinkConnectorConfig(properties);
+    properties.remove(StorageCommonConfig.STORE_URL_CONFIG);
+    assertEquals(url, connectorConfig.getUrl());
+  }
+
+  @Test
   public void testStorageClass() throws Exception {
     // No real test case yet
     connectorConfig = new HdfsSinkConnectorConfig(properties);

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.hdfs;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Before;
@@ -48,6 +49,19 @@ public class HdfsSinkConnectorConfigTest extends TestWithMiniDFSCluster {
   @Override
   public void setUp() throws Exception {
     super.setUp();
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testUrlConfigMustBeNonEmpty() {
+    properties.remove(StorageCommonConfig.STORE_URL_CONFIG);
+    properties.remove(HdfsSinkConnectorConfig.HDFS_URL_CONFIG);
+    connectorConfig = new HdfsSinkConnectorConfig(properties);
+  }
+
+  @Test
+  public void testStorageCommonUrlPreferred() {
+    connectorConfig = new HdfsSinkConnectorConfig(properties);
+    assertEquals(url, connectorConfig.getUrl());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskWithSecureHDFSTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskWithSecureHDFSTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.hdfs;
 
+import io.confluent.connect.storage.common.StorageCommonConfig;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
@@ -54,6 +55,8 @@ public class HdfsSinkTaskWithSecureHDFSTest extends TestWithSecureMiniDFSCluster
         sinkRecords.add(sinkRecord);
       }
     }
+
+    properties.remove(StorageCommonConfig.STORE_URL_CONFIG);
     task.initialize(context);
     task.start(properties);
     task.put(sinkRecords);

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskWithSecureHDFSTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskWithSecureHDFSTest.java
@@ -14,7 +14,6 @@
 
 package io.confluent.connect.hdfs;
 
-import io.confluent.connect.storage.common.StorageCommonConfig;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
@@ -24,11 +23,9 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.hdfs.avro.AvroDataFileReader;
-import io.confluent.connect.hdfs.avro.AvroFileReader;
 
 import static org.junit.Assert.assertEquals;
 
@@ -56,7 +53,6 @@ public class HdfsSinkTaskWithSecureHDFSTest extends TestWithSecureMiniDFSCluster
       }
     }
 
-    properties.remove(StorageCommonConfig.STORE_URL_CONFIG);
     task.initialize(context);
     task.start(properties);
     task.put(sinkRecords);

--- a/src/test/java/io/confluent/connect/hdfs/TestWithSecureMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithSecureMiniDFSCluster.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.hdfs;
 
+import io.confluent.connect.storage.common.StorageCommonConfig;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
@@ -149,6 +150,7 @@ public class TestWithSecureMiniDFSCluster extends HdfsSinkConnectorTestBase {
     Map<String, String> props = super.createProps();
     url = "hdfs://" + cluster.getNameNode().getClientNamenodeAddress();
     props.put(HdfsSinkConnectorConfig.HDFS_URL_CONFIG, url);
+    props.put(StorageCommonConfig.STORE_URL_CONFIG, url);
     props.put(HdfsSinkConnectorConfig.HDFS_AUTHENTICATION_KERBEROS_CONFIG, "true");
     // if we use the connect principal to authenticate with secure Hadoop, the following
     // error shows up: Auth failed for 127.0.0.1:63101:null (GSS initiate failed).


### PR DESCRIPTION
`hfds.url` was deprecated everywhere in the documentation for `store.url` but it was not reflected in the code and results in NPE

addresses the issue in [DOCS-1449](https://confluentinc.atlassian.net/browse/DOCS-1449)
and [here](https://confluentinc.atlassian.net/browse/CC-6196) 

Signed-off-by: Lev Zemlyanov <lev@confluent.io>