### PR TITLE
MINOR: don't close HDFS FileSystem, to avoid ClosedChannelException;

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
+++ b/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
@@ -125,11 +125,14 @@ public class HdfsStorage
   @Override
   public void close() {
     if (fs != null) {
+      // don't close FileSystem, to avoid ClosedChannelException;
+      /*
       try {
         fs.close();
       } catch (IOException e) {
         throw new ConnectException(e);
       }
+      */
     }
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -183,7 +183,8 @@ public class WALFile {
         log.error("Failed creating a WAL Writer: " + re.getMessage());
         if (re.getClassName().equals(WALConstants.LEASE_EXCEPTION_CLASS_NAME)) {
           if (fs != null) {
-            fs.close();
+            // don't close FileSystem, to avoid ClosedChannelException;
+            // fs.close();
           }
         }
         throw re;
@@ -465,7 +466,8 @@ public class WALFile {
         log.error("Failed creating a WAL Reader: " + re.getMessage());
         if (re.getClassName().equals(WALConstants.LEASE_EXCEPTION_CLASS_NAME)) {
           if (fs != null) {
-            fs.close();
+            // don't close FileSystem, to avoid ClosedChannelException;
+            // fs.close();
           }
         }
         throw re;


### PR DESCRIPTION
we comment these fs.Close(), and got much stability in production;