### PR TITLE
CC-6565: Adapt to parquet.codec addition but accept only SNAPPY for now

### DIFF
--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -388,6 +389,34 @@ public class HdfsSinkConnectorConfigTest extends TestWithMiniDFSCluster {
           break;
       }
     }
+  }
+
+  @Test
+  public void testParquetCompressionTypeSupported() {
+    properties.put(HdfsSinkConnectorConfig.PARQUET_CODEC_CONFIG, "snappy");
+    connectorConfig = new HdfsSinkConnectorConfig(properties);
+    assertEquals(CompressionCodecName.SNAPPY, connectorConfig.parquetCompressionCodecName());
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testUnsupportedParquetCompressionType() {
+    properties.put(HdfsSinkConnectorConfig.PARQUET_CODEC_CONFIG, "uncompressed");
+    connectorConfig = new HdfsSinkConnectorConfig(properties);
+    connectorConfig.parquetCompressionCodecName();
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testNotYetSupportedParquetCompressionTypeGzip() {
+    properties.put(HdfsSinkConnectorConfig.PARQUET_CODEC_CONFIG, "gzip");
+    connectorConfig = new HdfsSinkConnectorConfig(properties);
+    connectorConfig.parquetCompressionCodecName();
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testNotYetSupportedParquetCompressionTypeLz4() {
+    properties.put(HdfsSinkConnectorConfig.PARQUET_CODEC_CONFIG, "lz4");
+    connectorConfig = new HdfsSinkConnectorConfig(properties);
+    connectorConfig.parquetCompressionCodecName();
   }
 }
 


### PR DESCRIPTION
parquet.codec was added in storage-common added with a default value set to 'snappy'. This change adapts to this config addition but it does not enable additional codecs for now because this would result in the file format changing from <filename>.parquet to <filename>.<codec_extension>.parquet. 

The introduction of additional codec and the change in the filename format will have to wait for the next major release. 