### PR TITLE
[6.0] MINOR: remove explicit Hadoop versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,13 @@
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <forkCount>1</forkCount>
+                    <systemPropertyVariables>
+                        <datanucleus.schema.autoCreateAll>true</datanucleus.schema.autoCreateAll>
+                    </systemPropertyVariables>
+                    <additionalClasspathElements>
+                        <!--puts hive-site.xml on classpath - w/o HMS tables are not created-->
+                        <additionalClasspathElement>src/test/resources/conf</additionalClasspathElement>
+                    </additionalClasspathElements>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -202,8 +202,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all</arg>
-                        <arg>-Xlint:-deprecation</arg>
+                        <arg>-Xlint:all,-deprecation,-processing</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                     <showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
 
     <properties>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-        <hadoop.version>2.7.3</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
     </properties>

--- a/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
@@ -370,7 +370,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
 
     String result = HiveTestUtils.runHive(
         hiveExec,
-        "SELECT * FROM " + hiveMetaStore.tableNameConverter(TOPIC) + " order by country, state"
+        "SELECT * FROM " + hiveMetaStore.tableNameConverter(TOPIC)
     );
     String[] rows = result.split("\n");
     assertEquals(9, rows.length);

--- a/src/test/java/io/confluent/connect/hdfs/hive/HiveTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/hive/HiveTestBase.java
@@ -31,7 +31,7 @@ public class HiveTestBase extends TestWithMiniDFSCluster {
   @Override
   protected Map<String, String> createProps() {
     Map<String, String> props = super.createProps();
-    props.put(HiveConfig.HIVE_CONF_DIR_CONFIG, "hive_conf");
+    props.put(HiveConfig.HIVE_CONF_DIR_CONFIG, "src/test/resources/conf");
     return props;
   }
 

--- a/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
@@ -286,8 +286,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     String result = HiveTestUtils.runHive(
         hiveExec,
         "SELECT * FROM " +
-            hiveMetaStore.tableNameConverter(TOPIC) +
-            " order by country, state"
+            hiveMetaStore.tableNameConverter(TOPIC)
     );
     String[] rows = result.split("\n");
     assertEquals(expectedResults.size(), rows.length);

--- a/src/test/resources/conf/hive-site.xml
+++ b/src/test/resources/conf/hive-site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>hive.metastore.schema.verification</name>
+    <value>false</value>
+  </property>
+</configuration>


### PR DESCRIPTION
Rely on version picked up from parent `kafka-connect-storage-common` instead of explicitly specifying Hadoop version here.

Also, updates tests to pass with newer versions of Hadoop/Hive that are introduced in https://github.com/confluentinc/kafka-connect-storage-common/pull/123