### PR TITLE
MINOR: Disable compilation warning on annotations processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,7 @@
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Xlint:-deprecation</arg>
+                        <arg>-Xlint:-processing</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                     <showWarnings>true</showWarnings>


### PR DESCRIPTION
This should fix the build errors we're experiencing on this repo. Mirrors changes made for the [storage common repo](https://github.com/confluentinc/kafka-connect-storage-common/commit/286b9b80e0fbac7ef98e6c01eba26e20c853491c#diff-600376dffeb79835ede4a0b285078036R177).