### PR TITLE
CC-7360: Recover gracefully if closing a temporary file fails

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -751,8 +751,9 @@ public class TopicPartitionWriter {
         // still want to close all of the other data writers
         connectException = e;
         log.error(
-            "Failed to close temporary file for partition " + encodedPartition
-                + ". The connector will attempt to rewrite the temporary file."
+            "Failed to close temporary file for partition {}. The connector will attempt to"
+                + " rewrite the temporary file.",
+            encodedPartition
         );
       }
     }
@@ -765,7 +766,7 @@ public class TopicPartitionWriter {
         try {
           deleteTempFile(encodedPartition);
         } catch (ConnectException e) {
-          log.error("Failed to delete tmp file " + tempFiles.get(encodedPartition), e);
+          log.error("Failed to delete tmp file {}", tempFiles.get(encodedPartition), e);
         }
         startOffsets.remove(encodedPartition);
         offsets.remove(encodedPartition);

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -754,6 +754,9 @@ public class TopicPartitionWriter {
         buffer.clear();
       }
 
+      log.debug("Resetting offset for {} to {}", tp, offset);
+      context.offset(tp, offset);
+
       recordCounter = 0;
       throw connectException;
     }

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -738,6 +738,10 @@ public class TopicPartitionWriter {
       } catch (ConnectException e) {
         // still want to close all of the other data writers
         connectException = e;
+        log.error(
+            "Failed to close temporary file for partition " + encodedPartition
+                + ". The connector will attempt to rewrite the temporary file."
+        );
       }
     }
 

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -750,7 +750,11 @@ public class TopicPartitionWriter {
       // delete all buffered records + tmp files and start over because otherwise there will be
       // duplicates, since there is no way to reclaim the records in the tmp file.
       for (String encodedPartition : tempFiles.keySet()) {
-        deleteTempFile(encodedPartition);
+        try {
+          deleteTempFile(encodedPartition);
+        } catch (ConnectException e) {
+          log.error("Failed to delete tmp file " + tempFiles.get(encodedPartition), e);
+        }
         startOffsets.remove(encodedPartition);
         offsets.remove(encodedPartition);
         buffer.clear();

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -746,7 +746,9 @@ public class TopicPartitionWriter {
     }
 
     if (connectException != null) {
-      // at least one tmp file did not close properly
+      // at least one tmp file did not close properly therefore will try to recreate the tmp and
+      // delete all buffered records + tmp files and start over because otherwise there will be
+      // duplicates, since there is no way to reclaim the records in the tmp file.
       for (String encodedPartition : tempFiles.keySet()) {
         deleteTempFile(encodedPartition);
         startOffsets.remove(encodedPartition);

--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -275,7 +275,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(properties);
 
     ArrayList<SinkRecord> sinkRecords = createRecords(PARTITION, 0, 1);
-    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData, time);
     hdfsWriter.write(sinkRecords);
 
     sinkRecords = createRecords(PARTITION, 1, 6);
@@ -292,7 +292,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     sinkRecords = createRecords(PARTITION, 0, 7);
     hdfsWriter.write(sinkRecords);
 
-    Thread.sleep(context.timeout());
+    time.sleep(context.timeout());
     hdfsWriter.write(new ArrayList<>());
 
     Map<String, List<Object>> data = Data.getData();
@@ -308,7 +308,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     writer.setFailure(Failure.closeFailure);
     hdfsWriter.write(createRecords(PARTITION, 7, 2));
 
-    Thread.sleep(context.timeout());
+    time.sleep(context.timeout());
     hdfsWriter.write(new ArrayList<>());
     assertEquals(6, hdfsWriter.getCommittedOffsets().get(new TopicPartition(TOPIC, PARTITION)).longValue());
 

--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -62,7 +62,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
   }
 
   @Test
-  public void testCommitFailure() throws Exception {
+  public void testCommitFailure() {
     String key = "key";
     Schema schema = createSchema();
     Struct record = createRecord(schema);
@@ -87,12 +87,12 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     List<Object> content = data.get(logFile);
     assertEquals(null, content);
 
-    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.write(new ArrayList<>());
     content = data.get(logFile);
     assertEquals(null, content);
 
     time.sleep(context.timeout());
-    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.write(new ArrayList<>());
     content = data.get(logFile);
     assertEquals(6, content.size());
 
@@ -133,7 +133,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     // Simulate an exception thrown from HDFS during WAL append
     storage.setFailure(MemoryStorage.Failure.appendFailure);
     Data.logContents("Before failure");
-    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.write(new ArrayList<>());
     Data.logContents("After failure");
     // 3 is in a tmp file with the writer closed
 
@@ -156,7 +156,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
       String path = FileUtils.committedFileName(
           url,
           topicsDir,
-          TOPIC + "/" + "partition=" + String.valueOf(PARTITION),
+          TOPIC + "/" + "partition=" + PARTITION,
           TOPIC_PARTITION,
           startOffset,
           endOffset,
@@ -174,7 +174,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
   }
 
   @Test
-  public void testWriterFailureMultiPartitions() throws Exception {
+  public void testWriterFailureMultiPartitions() {
     String key = "key";
     Schema schema = createSchema();
     Struct record = createRecord(schema);
@@ -199,7 +199,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
       sinkRecords.add(sinkRecord);
     }
 
-    String encodedPartition = "partition=" + String.valueOf(PARTITION);
+    String encodedPartition = "partition=" + PARTITION;
     Map<String, io.confluent.connect.storage.format.RecordWriter> writers = hdfsWriter.getWriters(TOPIC_PARTITION);
     MemoryRecordWriter writer = (MemoryRecordWriter) writers.get(encodedPartition);
     writer.setFailure(MemoryRecordWriter.Failure.writeFailure);
@@ -208,7 +208,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     assertEquals(context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
 
     Map<String, List<Object>> data = Data.getData();
-    String directory2 = TOPIC + "/" + "partition=" + String.valueOf(PARTITION2);
+    String directory2 = TOPIC + "/" + "partition=" + PARTITION2;
     long[] validOffsets = {-1, 2, 5};
     for (int i = 1; i < validOffsets.length; i++) {
       long startOffset = validOffsets[i - 1] + 1;
@@ -221,7 +221,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     }
 
     writer.setFailure(MemoryRecordWriter.Failure.closeFailure);
-    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.write(new ArrayList<>());
     assertEquals(context.timeout(), (long) connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
 
     Map<String, String> tempFileNames = hdfsWriter.getTempFileNames(TOPIC_PARTITION);
@@ -234,20 +234,20 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     }
 
     time.sleep(context.timeout());
-    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.write(sinkRecords.subList(6, 12)); // remove records for the successful partition
     assertEquals(3, content.size());
     for (int i = 0; i < content.size(); ++i) {
       SinkRecord refSinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, i);
       assertEquals(refSinkRecord, content.get(i));
     }
 
-    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.write(new ArrayList<>());
     hdfsWriter.close();
     hdfsWriter.stop();
   }
 
   @Test
-  public void testWriterFailure() throws Exception {
+  public void testWriterFailure() {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(properties);
 
     String key = "key";
@@ -266,7 +266,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
       sinkRecords.add(sinkRecord);
     }
 
-    String encodedPartition = "partition=" + String.valueOf(PARTITION);
+    String encodedPartition = "partition=" + PARTITION;
     Map<String, io.confluent.connect.storage.format.RecordWriter> writers = hdfsWriter.getWriters(TOPIC_PARTITION);
     MemoryRecordWriter writer = (MemoryRecordWriter) writers.get(encodedPartition);
 
@@ -276,7 +276,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
 
     writer.setFailure(MemoryRecordWriter.Failure.closeFailure);
     // nothing happens as we the retry back off hasn't yet passed
-    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.write(new ArrayList<>());
     Map<String, List<Object>> data = Data.getData();
 
     Map<String, String> tempFileNames = hdfsWriter.getTempFileNames(TOPIC_PARTITION);
@@ -290,7 +290,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     }
 
     time.sleep(context.timeout());
-    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.write(sinkRecords);
 
     tempFileNames = hdfsWriter.getTempFileNames(TOPIC_PARTITION);
     tempFileName = tempFileNames.get(encodedPartition);
@@ -302,7 +302,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
       assertEquals(refSinkRecord, content.get(i));
     }
 
-    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.write(new ArrayList<>());
     hdfsWriter.close();
     hdfsWriter.stop();
   }


### PR DESCRIPTION
## Problem
<!--- Describe the problem and context that this PR is supposed to address.  --> 
Sometimes closing a temporary file fails, which means the file does not get flushed properly and therefore may result empty or corrupted files in HDFS showing up. 

## Solution
<!--- Describe the high level solution that this PR implements to solve the problem. -->
If a temporary file does not close the file, the connector will take the most conservative approach and will delete the temporary file attempt to rewrite all the records from scratch.

Note that this PR does not address closing temporary files when closing the `TopicPartitionWriter`. That should be addressed in a different PR.

##### Does this solution apply anywhere else?
<!--- For example, are there other connectors with the same problem? -->
- [x] yes
- [ ] no

##### If yes, where?
<!--- Where else should this be fixed? -->
HDFS3 could face a similar issue

## Testing
<!-- Describe your test coverage. -->
Added a unit test that makes sure that the connector correctly handles the offsets and close failures. 

I also ran manual tests where I simulated closing failures (5% of the time) and see how the connector addresses them. They were a success.

![Screen Shot 2020-06-19 at 2 22 13 PM](https://user-images.githubusercontent.com/14001489/85180422-514af100-b238-11ea-9949-7f4af68bd2fc.png)


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release plan
<!--- Describe the release plan for this feature. Are you backporting or merging to master and etc. -->
Backporting to 5.0.x when this bug was introduced by #451 

Signed-off-by: Lev Zemlyanov <lev@confluent.io>