### PR TITLE
CC-9710: Retry effectively on exceptions from time-based commits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,7 @@
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Xlint:-deprecation</arg>
+                        <arg>-Werror</arg>
                     </compilerArgs>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>false</showDeprecation>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,6 @@
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Xlint:-deprecation</arg>
-                        <arg>-Werror</arg>
                     </compilerArgs>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>false</showDeprecation>

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -420,14 +420,14 @@ public class TopicPartitionWriter {
           case WRITE_PARTITION_PAUSED:
             // committing files after waiting for rotateIntervalMs time but less than flush.size
             // records available
-            if (recordCounter > 0 && shouldRotateAndMaybeUpdateTimers(currentRecord, now)) {
-              log.info(
+            if (recordCounter == 0 || !shouldRotateAndMaybeUpdateTimers(currentRecord, now)) {
+              break;
+            } 
+            
+            log.info(
                   "committing files after waiting for rotateIntervalMs time but less than "
                       + "flush.size records available."
-              );
-            } else {
-              break;
-            }
+            );
             nextState();
           case SHOULD_ROTATE:
             updateRotationTimers(currentRecord);

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -412,24 +412,43 @@ public class TopicPartitionWriter {
       }
     }
     if (buffer.isEmpty()) {
-      // committing files after waiting for rotateIntervalMs time but less than flush.size
-      // records available
-      if (recordCounter > 0 && shouldRotateAndMaybeUpdateTimers(currentRecord, now)) {
-        log.info(
-            "committing files after waiting for rotateIntervalMs time but less than flush.size "
-                + "records available."
-        );
-        updateRotationTimers(currentRecord);
-
-        try {
-          closeTempFile();
-          appendToWAL();
-          commitFile();
-        } catch (ConnectException e) {
-          log.error("Exception on topic partition {}: ", tp, e);
-          failureTime = time.milliseconds();
-          setRetryTimeout(timeoutMs);
+      try {
+        switch (state) {
+          case WRITE_STARTED:
+            pause();
+            nextState();
+          case WRITE_PARTITION_PAUSED:
+            // committing files after waiting for rotateIntervalMs time but less than flush.size
+            // records available
+            if (recordCounter > 0 && shouldRotateAndMaybeUpdateTimers(currentRecord, now)) {
+              log.info(
+                  "committing files after waiting for rotateIntervalMs time but less than "
+                      + "flush.size records available."
+              );
+            } else {
+              break;
+            }
+            nextState();
+          case SHOULD_ROTATE:
+            updateRotationTimers(currentRecord);
+            closeTempFile();
+            nextState();
+          case TEMP_FILE_CLOSED:
+            appendToWAL();
+            nextState();
+          case WAL_APPENDED:
+            commitFile();
+            nextState();
+          case FILE_COMMITTED:
+            break;
+          default:
+            log.error("{} is not a valid state to empty batch for topic partition {}.", state, tp);
         }
+      } catch (ConnectException e) {
+        log.error("Exception on topic partition {}: ", tp, e);
+        failureTime = time.milliseconds();
+        setRetryTimeout(timeoutMs);
+        return;
       }
 
       resume();

--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -32,7 +32,6 @@ import io.confluent.connect.hdfs.utils.MemoryFormat;
 import io.confluent.connect.hdfs.utils.MemoryRecordWriter;
 import io.confluent.connect.hdfs.utils.MemoryStorage;
 import io.confluent.connect.storage.common.StorageCommonConfig;
-import io.confluent.connect.storage.format.*;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -132,13 +132,13 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
 
     // Perform a normal write immediately afterwards
     deliver(consumerOffset, hdfsWriter, key, schema, record, 6);
-    // 3 has been lost when the writer is re-opened and overwrites the existing file
-    // 4, 5 are written to the file and the file is committed as 3-4-5
-    // 6 and beyond are written normally
+    // 3 is appended to the wal and committed
+    // 4, 5, 6 are written to a new file
+    // 7 and beyond are written normally
 
     Data.logContents("After test");
 
-    long[] validOffsets = {-1, 2, 5, 8};
+    long[] validOffsets = {-1, 2, 3, 6, 9};
     for (int i = 1; i < validOffsets.length; i++) {
       long startOffset = validOffsets[i - 1] + 1;
       long endOffset = validOffsets[i];

--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -15,8 +15,9 @@
 package io.confluent.connect.hdfs;
 
 import io.confluent.common.utils.MockTime;
-import io.confluent.common.utils.Time;
 import io.confluent.connect.storage.StorageSinkConnectorConfig;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -42,7 +43,8 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
   private static final String ZERO_PAD_FMT = "%010d";
   private static final String extension = "";
 
-  private Time time;
+  private Map<String, String> localProps = new HashMap<>();
+  private MockTime time;
 
   @Before
   public void setUp() throws Exception {
@@ -56,7 +58,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     Map<String, String> props = super.createProps();
     props.put(StorageCommonConfig.STORAGE_CLASS_CONFIG, MemoryStorage.class.getName());
     props.put(HdfsSinkConnectorConfig.FORMAT_CLASS_CONFIG, MemoryFormat.class.getName());
-    props.put(StorageSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "60000");
+    props.putAll(localProps);
     return props;
   }
 
@@ -101,6 +103,11 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
 
   @Test
   public void testRotateAppendFailure() throws Exception {
+    localProps.put(
+        HdfsSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.MINUTES.toMillis(10))
+    );
+    setUp();
     String key = "key";
     Schema schema = createSchema();
     Struct record = createRecord(schema);

--- a/src/test/java/io/confluent/connect/hdfs/utils/Data.java
+++ b/src/test/java/io/confluent/connect/hdfs/utils/Data.java
@@ -20,11 +20,37 @@ package io.confluent.connect.hdfs.utils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Data {
   private static final Map<String, List<Object>> data = new HashMap<>();
 
+  private static final Logger log = LoggerFactory.getLogger(Data.class);
+
   public static Map<String, List<Object>> getData() {
     return data;
+  }
+
+  public static void logContents(String message) {
+    if (log.isDebugEnabled()) {
+      log.debug("{}: {}",
+          message,
+          data.entrySet()
+              .stream()
+              .map(e -> e.getKey()
+                      + "="
+                      + (
+                      e.getValue() != null
+                          ? (e.getValue()
+                          .stream()
+                          .map(Object::toString)
+                          .collect(Collectors.joining(",\n\t", "[\n\t", "]")))
+                          : "null"
+                  )
+              )
+              .collect(Collectors.joining(",\n")));
+    }
   }
 }

--- a/src/test/java/io/confluent/connect/hdfs/utils/MemoryRecordWriterProvider.java
+++ b/src/test/java/io/confluent/connect/hdfs/utils/MemoryRecordWriterProvider.java
@@ -37,9 +37,8 @@ public class MemoryRecordWriterProvider
   ) {
     final Map<String, List<Object>> data = Data.getData();
 
-    if (!data.containsKey(filename)) {
-      data.put(filename, new LinkedList<>());
-    }
+    // Overwrite the existing file in storage like every other writer provider
+    data.put(filename, new LinkedList<>());
 
     return new MemoryRecordWriter(filename);
   }

--- a/src/test/java/io/confluent/connect/hdfs/utils/MemoryWAL.java
+++ b/src/test/java/io/confluent/connect/hdfs/utils/MemoryWAL.java
@@ -94,5 +94,10 @@ public class MemoryWAL implements WAL {
     public String value() {
       return value;
     }
+
+    @Override
+    public String toString() {
+      return key + "=" + value;
+    }
   }
 }


### PR DESCRIPTION
## Problem
Exceptions thrown from time-based commits (in particular exceptions from appending to the WAL) aren't retried effectively, leading to corrupted files. 

* When an exception is thrown during time-based commits, the state machine is still updated to WRITE_STARTED
* When recovering in a subsequent non-empty write, the WRITE_STARTED state triggers the writer to start a new file, since the previous file was closed but not committed.
* This leads to the loss of the contents of the previous file, and corruption of the current file's offsets.

This test setup expects that the files 0-2, 3, 4-6 are created, but without the accompanying fix in the TopicPartitionWriter, the files 0-2 and 3-5 are created, and the 3-5 file is missing record 3, which was delivered in the initial batch and then overwritten.
## Solution

The time-based commits should keep the state-machine up-to-date, such that any recovery (non-empty or empty) will cleanly recover the file.

Also addresses minor bug where the memory format didn't properly overwrite data when the file was re-opened.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?

This needs to be ported to HDFS3. https://confluentinc.atlassian.net/browse/CC-9759

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
This will be backported to 5.0.x and released in the next patch releases of CP.
This change is safe to roll back, but data corruption as a result of the underlying bug will need manual remediation.
