### PR TITLE
MINOR: fix build error from bad merge

### DIFF
--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -156,7 +156,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
       long endOffset = validOffsets[i];
       String path = FileUtils.committedFileName(
           url,
-          topicsDir,
+          topicsDir.getOrDefault(TOPIC, StorageCommonConfig.TOPICS_DIR_DEFAULT),
           TOPIC + "/" + "partition=" + String.valueOf(PARTITION),
           TOPIC_PARTITION,
           startOffset,


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
#477 changed `topicsDir` to be a hashmap and #503 introduced a new test that relied on `topicsDir` as a string

## Solution
fetch the desired string from the map

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
make sure the connector compiles and builds

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
issue is found in `5.5.x`