### PR TITLE
CC-9755: Validate timezone configuration with rotate.schedule.interva…

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -308,6 +308,25 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     addToGlobal(commonConfig);
     addToGlobal(this);
     this.url = extractUrl();
+    validateTimezone();
+  }
+
+  /**
+   * Validate the timezone with the rotate.schedule.interval.ms config,
+   * these need validation before use in the TopicPartitionWriter.
+   */
+  private void validateTimezone() {
+    String timezone = getString(PartitionerConfig.TIMEZONE_CONFIG);
+    long rotateScheduleIntervalMs = getLong(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG);
+    if (rotateScheduleIntervalMs > 0 && timezone.isEmpty()) {
+      throw new ConfigException(
+          String.format(
+              "%s configuration must be set when using %s",
+              PartitionerConfig.TIMEZONE_CONFIG,
+              ROTATE_SCHEDULE_INTERVAL_MS_CONFIG
+          )
+      );
+    }
   }
 
   public static Map<String, String> addDefaults(Map<String, String> props) {

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
@@ -89,6 +89,36 @@ public class HdfsSinkConnectorConfigTest extends TestWithMiniDFSCluster {
   }
 
   @Test
+  public void testValidTimezoneWithScheduleIntervalAccepted (){
+    properties.put(PartitionerConfig.TIMEZONE_CONFIG, "CET");
+    properties.put(HdfsSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "30");
+    new HdfsSinkConnectorConfig(properties);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testEmptyTimezoneThrowsExceptionOnScheduleInterval() {
+    properties.put(PartitionerConfig.TIMEZONE_CONFIG, PartitionerConfig.TIMEZONE_DEFAULT);
+    properties.put(HdfsSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "30");
+    new HdfsSinkConnectorConfig(properties);
+  }
+
+  @Test
+  public void testEmptyTimezoneExceptionMessage() {
+    properties.put(PartitionerConfig.TIMEZONE_CONFIG, PartitionerConfig.TIMEZONE_DEFAULT);
+    properties.put(HdfsSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "30");
+    String expectedError =  String.format(
+        "%s configuration must be set when using %s",
+        PartitionerConfig.TIMEZONE_CONFIG,
+        HdfsSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG
+    );
+    try {
+      new HdfsSinkConnectorConfig(properties);
+    } catch (ConfigException e) {
+      assertEquals(expectedError, e.getMessage());
+    }
+  }
+
+  @Test
   public void testRecommendedValues() throws Exception {
     List<Object> expectedStorageClasses = Arrays.<Object>asList(HdfsStorage.class);
 


### PR DESCRIPTION
## Problem
The `timezone` configuration is not being validated when the `TimeBasedPartitioner` is not set. This results in a runtime error when the `rotate.schedule.interval.ms` is used and an invalid or no `timezone` value is set. 

## Solution
Validate the `timezone` configuration whenever set, and expect the `timezone` configuration to be set when `rotate.schedule.interval.ms` is used. 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [X] yes
- [ ] no

##### If yes, where?
All storage sink connectors that use the timezone configuration.

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backporting to 4.0.x.  