### PR TITLE
CC-8704: Resolve jetty CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-hive</artifactId>
             <version>${confluent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.aggregate</groupId>
+                    <artifactId>jetty-all</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
## Problem
This PR addresses a CVE caused by `jetty-all 7.6.0.v20120127`. 

## Solution
Exclude the `jetty-all` dependency that is brought in by `kafka-connect-storage-hive`, same solution as in [gcp-dataproc](https://github.com/confluentinc/kafka-connect-gcp-dataproc/blob/master/pom.xml#L353-L356) and [object-store-source](https://github.com/confluentinc/kafka-connect-object-store-source/blob/master/sink-integration-tests/pom.xml#L190-L193) connectors. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [X] yes
- [ ] no

##### If yes, where?
All connectors using `jetty-all 7.6.0.v20120127`.

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [x] Integration tests
- [x] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backporting to 5.4.x. 
