### PR TITLE
Fix for hive parquet duplicate columns while using field partitioner

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtil.java
@@ -54,6 +54,15 @@ public class ParquetHiveUtil extends HiveUtil {
   public void alterSchema(String database, String tableName, Schema schema) {
     Table table = hiveMetaStore.getTable(database, tableName);
     List<FieldSchema> columns = HiveSchemaConverter.convertSchema(schema);
+    List<FieldSchema> partitions = table.getPartCols();
+    for (FieldSchema partition : partitions) {
+      for (FieldSchema column : columns) {
+        if (partition.getName().equals(column.getName())) {
+          columns.remove(column);
+          break;
+        }
+      }
+    }
     table.setFields(columns);
     hiveMetaStore.alterTable(table);
   }
@@ -79,8 +88,17 @@ public class ParquetHiveUtil extends HiveUtil {
     }
     // convert Connect schema schema to Hive columns
     List<FieldSchema> columns = HiveSchemaConverter.convertSchema(schema);
+    List<FieldSchema> partitions = partitioner.partitionFields();
+    for (FieldSchema partition : partitions) {
+      for (FieldSchema column : columns) {
+        if (partition.getName().equals(column.getName())) {
+          columns.remove(column);
+          break;
+        }
+      }
+    }
     table.setFields(columns);
-    table.setPartCols(partitioner.partitionFields());
+    table.setPartCols(partitions);
     return table;
   }
 

--- a/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
@@ -156,6 +156,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
 
     Schema schema = createSchema();
+	Field partitionField = schema.field("int");
     List<Struct> records = createRecordBatches(schema, 3, 3);
     List<SinkRecord> sinkRecords = createSinkRecords(records, schema);
 
@@ -167,7 +168,8 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
 
     List<String> expectedColumnNames = new ArrayList<>();
     for (Field field : schema.fields()) {
-      expectedColumnNames.add(field.name());
+      if(!field.name().equals(partitionField.name()))
+        expectedColumnNames.add(field.name());
     }
 
     List<String> actualColumnNames = new ArrayList<>();
@@ -199,7 +201,8 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
       for (int j = 0; j < 3; ++j) {
         List<String> result = new ArrayList<>();
         for (Field field : schema.fields()) {
-          result.add(String.valueOf(records.get(i).get(field.name())));
+          if(!field.name().equals(partitionField.name()))
+            result.add(String.valueOf(records.get(i).get(field.name())));
         }
         expectedResults.add(result);
       }
@@ -233,6 +236,10 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
         .field("country", Schema.STRING_SCHEMA)
         .field("state", Schema.OPTIONAL_STRING_SCHEMA)
         .build();
+		
+	List<String> partitionFieldNames = new ArrayList<>();
+    partitionFieldNames.add("country");
+    partitionFieldNames.add("state");
 
     List<Struct> records = Arrays.asList(
         new Struct(schema)
@@ -258,7 +265,8 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
 
     List<String> expectedColumnNames = new ArrayList<>();
     for (Field field : schema.fields()) {
-      expectedColumnNames.add(field.name());
+      if(!partitionFieldNames.contains(field.name()))
+        expectedColumnNames.add(field.name());
     }
 
     List<String> actualColumnNames = new ArrayList<>();
@@ -278,7 +286,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     assertEquals(expectedPartitions, partitions);
 
     List<List<String>> expectedResults = Arrays.asList(
-        Arrays.asList("1", "mx", "NULL"),
+        Arrays.asList("1", "mx", "null"),
         Arrays.asList("1", "us", "ca"),
         Arrays.asList("1", "us", "tx")
     );


### PR DESCRIPTION
## Problem
field partitioner creates duplicate hive parquet partition columns.

## Solution
Check if the column is a partition column and ignore them while creating the table.

references:
https://github.com/confluentinc/kafka-connect-hdfs/pull/336/files
https://github.com/confluentinc/kafka-connect-hdfs/issues/238
https://github.com/confluentinc/kafka-connect-hdfs/issues/221
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
unit tests updated accordingly.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
