### PR TITLE
Recover the offset from HDFS, even if topic name is not present in storage path

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -31,6 +31,7 @@ import java.util.regex.Matcher;
 
 import io.confluent.connect.hdfs.filter.CommittedFileFilter;
 import io.confluent.connect.hdfs.storage.Storage;
+import io.confluent.connect.storage.common.StorageCommonConfig;
 
 public class FileUtils {
   private static final Logger log = LoggerFactory.getLogger(FileUtils.class);
@@ -101,7 +102,12 @@ public class FileUtils {
   }
 
   public static String topicDirectory(String url, String topicsDir, String topic) {
-    return url + "/" + topicsDir + "/" + topic;
+    boolean topicInPath = Boolean.valueOf(StorageCommonConfig.PATH_INCLUDE_TOPICNAME_CONFIG);
+    if (topicInPath) {
+      return url + "/" + topicsDir + "/" + topic;
+    } else {
+      return url + "/" + topicsDir;
+    }
   }
 
   public static FileStatus fileStatusWithMaxOffset(

--- a/src/test/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitionerTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitionerTest.java
@@ -66,6 +66,7 @@ public class TimeBasedPartitionerTest extends HdfsSinkConnectorTestBase {
 
     @Override
     public void configure(Map<String, Object> config) {
+      super.configure(config);
       init(partitionDurationMs, pathFormat, Locale.FRENCH, DATE_TIME_ZONE, config);
     }
 


### PR DESCRIPTION
#346  Problem
Exactly-once semantics should also work without topic name included in the path.

## Solution
The function that recover offsets from file names will use the correct path by taking into account a new configuration flag `path_include_topicname ` introduced with confluentinc/kafka-connect-storage-common#126.

Further, the backward compatibility of appending the topic name is retained by default value `true` for `path_include_topicname`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
This change is necessary to retain EOS semantics to support flexible storage partitioning scheme as proposed here: confluentinc/kafka-connect-storage-common#126


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
