### PR TITLE
CC-9887: Update avro data initialization to set all avro parameters

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroFormat.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroFormat.java
@@ -32,9 +32,7 @@ public class AvroFormat
   // DO NOT change this signature, it is required for instantiation via reflection
   public AvroFormat(HdfsStorage storage) {
     this.storage = storage;
-    this.avroData = new AvroData(
-        storage.conf().getInt(HdfsSinkConnectorConfig.SCHEMA_CACHE_SIZE_CONFIG)
-    );
+    this.avroData = new AvroData(storage.conf().avroDataConfig());
   }
 
   @Override


### PR DESCRIPTION
## Problem
HDFS connector configurations, specifically `connect.meta.data` and `enhanced.avro.schema.support` essentially NOOP when configured; they are ignored when `AvroData` is configured.

## Solution
Update avro data instantiation to set all avro related parameters

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes Azure
- [ ] no

##### If yes, where?


## Test Strategy
TODO: Unit Tests

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
