### PR TITLE
CC-12567: Fix duplicate columns in Hive for Parquet and Avro formats

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroHiveUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroHiveUtil.java
@@ -70,7 +70,7 @@ public class AvroHiveUtil extends HiveUtil {
       Schema schema
   ) throws HiveMetaStoreException {
     Table table = hiveMetaStore.getTable(database, tableName);
-    Schema filteredSchema = filteredSchema(schema, table.getPartitionKeys());
+    Schema filteredSchema = filterSchema(schema, table.getPartitionKeys());
     table.getParameters().put(AVRO_SCHEMA_LITERAL,
         avroData.fromConnectSchema(filteredSchema).toString());
     hiveMetaStore.alterTable(table);
@@ -100,7 +100,7 @@ public class AvroHiveUtil extends HiveUtil {
     removeFieldPartitionColumn(columns, partitioner.partitionFields());
     table.setFields(columns);
     table.setPartCols(partitioner.partitionFields());
-    Schema filteredSchema = filteredSchema(schema, partitioner.partitionFields());
+    Schema filteredSchema = filterSchema(schema, partitioner.partitionFields());
     table.getParameters().put(AVRO_SCHEMA_LITERAL,
         avroData.fromConnectSchema(filteredSchema).toString());
     return table;
@@ -114,7 +114,7 @@ public class AvroHiveUtil extends HiveUtil {
    * @param partitionFields the fields used for partitioning
    * @return the new schema without the fields used for partitioning
    */
-  private Schema filteredSchema(Schema oldSchema, List<FieldSchema> partitionFields) {
+  private Schema filterSchema(Schema oldSchema, List<FieldSchema> partitionFields) {
     Set<String> partitions = partitionFields.stream()
         .map(FieldSchema::getName).collect(Collectors.toSet());
 

--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroHiveUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroHiveUtil.java
@@ -113,7 +113,10 @@ public class AvroHiveUtil extends HiveUtil {
    * @param partitionFields the fields used for partitioning
    * @return the new schema without the fields used for partitioning
    */
-  private Schema excludePartitionFieldsFromSchema(Schema originalSchema, List<FieldSchema> partitionFields) {
+  private Schema excludePartitionFieldsFromSchema(
+      Schema originalSchema,
+      List<FieldSchema> partitionFields
+  ) {
     Set<String> partitions = partitionFields.stream()
         .map(FieldSchema::getName).collect(Collectors.toSet());
 

--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtil.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.hdfs.parquet;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -54,6 +56,7 @@ public class ParquetHiveUtil extends HiveUtil {
   public void alterSchema(String database, String tableName, Schema schema) {
     Table table = hiveMetaStore.getTable(database, tableName);
     List<FieldSchema> columns = HiveSchemaConverter.convertSchema(schema);
+    removeFieldPartitionColumn(columns, table.getPartitionKeys());
     table.setFields(columns);
     hiveMetaStore.alterTable(table);
   }
@@ -79,6 +82,7 @@ public class ParquetHiveUtil extends HiveUtil {
     }
     // convert Connect schema schema to Hive columns
     List<FieldSchema> columns = HiveSchemaConverter.convertSchema(schema);
+    removeFieldPartitionColumn(columns, partitioner.partitionFields());
     table.setFields(columns);
     table.setPartCols(partitioner.partitionFields());
     return table;
@@ -118,5 +122,21 @@ public class ParquetHiveUtil extends HiveUtil {
     } catch (ClassNotFoundException ex) {
       return oldClass;
     }
+  }
+
+  /**
+   * Remove the column that is later re-created by Hive when using the
+   * {@code partition.field.name} config.
+   *
+   * @param columns the hive columns from
+   *                {@link HiveSchemaConverter#convertSchema(Schema) convertSchema}.
+   * @param partitionFields the fields used for partitioning
+   */
+  private void removeFieldPartitionColumn(List<FieldSchema> columns,
+      List<FieldSchema> partitionFields) {
+    Set<String> partitions = partitionFields.stream()
+        .map(FieldSchema::getName).collect(Collectors.toSet());
+
+    columns.removeIf(column -> partitions.contains(column.getName()));
   }
 }

--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtil.java
@@ -132,8 +132,10 @@ public class ParquetHiveUtil extends HiveUtil {
    *                {@link HiveSchemaConverter#convertSchema(Schema) convertSchema}.
    * @param partitionFields the fields used for partitioning
    */
-  private void removeFieldPartitionColumn(List<FieldSchema> columns,
-      List<FieldSchema> partitionFields) {
+  private void removeFieldPartitionColumn(
+      List<FieldSchema> columns,
+      List<FieldSchema> partitionFields
+  ) {
     Set<String> partitions = partitionFields.stream()
         .map(FieldSchema::getName).collect(Collectors.toSet());
 

--- a/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.hdfs.avro;
 
+import java.util.Collections;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.kafka.connect.data.Field;
@@ -210,27 +211,17 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
 
   @Test
   public void testHiveIntegrationFieldPartitionerAvro() throws Exception {
+    int batchSize = 3;
+    int batchNum = 3;
     localProps.put(HiveConfig.HIVE_INTEGRATION_CONFIG, "true");
     localProps.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, FieldPartitioner.class.getName());
     localProps.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "int");
     setUp();
-
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
 
-    String key = "key";
     Schema schema = createSchema();
-
-    Struct[] records = createRecords(schema);
-    ArrayList<SinkRecord> sinkRecords = new ArrayList<>();
-    long offset = 0;
-    for (Struct record : records) {
-      for (long count = 0; count < 3; count++) {
-        SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record,
-                                               offset + count);
-        sinkRecords.add(sinkRecord);
-      }
-      offset = offset + 3;
-    }
+    List<Struct> records = createRecordBatches(schema, batchSize, batchNum);
+    List<SinkRecord> sinkRecords = createSinkRecords(records, schema);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close();
@@ -239,17 +230,20 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
 
     List<String> expectedColumnNames = new ArrayList<>();
-    for (Field field: schema.fields()) {
+    for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
     }
+    Collections.sort(expectedColumnNames);
 
     List<String> actualColumnNames = new ArrayList<>();
-    for (FieldSchema column: table.getSd().getCols()) {
+    for (FieldSchema column : table.getAllCols()) {
       actualColumnNames.add(column.getName());
     }
+    Collections.sort(actualColumnNames);
+
     assertEquals(expectedColumnNames, actualColumnNames);
 
-    List<String> partitionFieldNames= connectorConfig.getList(
+    List<String> partitionFieldNames = connectorConfig.getList(
         PartitionerConfig.PARTITION_FIELD_NAME_CONFIG
     );
     String partitionFieldName = partitionFieldNames.get(0);
@@ -267,23 +261,32 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
 
     assertEquals(expectedPartitions, partitions);
 
-    ArrayList<String[]> expectedResult = new ArrayList<>();
-    for (int i = 16; i <= 18; ++i) {
-      String[] part = {"true", String.valueOf(i), "12", "12.2", "12.2"};
-      for (int j = 0; j < 3; ++j) {
-        expectedResult.add(part);
+    Struct sampleRecord = createRecord(schema, 16, 12.2f);
+    List<List<String>> expectedResults = new ArrayList<>();
+    for (int batch = 0; batch < batchNum; ++batch) {
+      int intForBatch =  sampleRecord.getInt32("int") + batch;
+      float floatForBatch =  sampleRecord.getFloat32("float") + (float) batch;
+      double doubleForBatch = sampleRecord.getFloat64("double") + (double) batch;
+      for (int row = 0; row < batchSize; ++row) {
+        // the partition field as column is last
+        List<String> result = new ArrayList<>(
+            Arrays.asList("true", String.valueOf(intForBatch), String.valueOf(floatForBatch),
+                String.valueOf(doubleForBatch), String.valueOf(intForBatch)));
+        expectedResults.add(result);
       }
     }
+
     String result = HiveTestUtils.runHive(
         hiveExec,
         "SELECT * FROM " + hiveMetaStore.tableNameConverter(TOPIC)
     );
     String[] rows = result.split("\n");
-    assertEquals(9, rows.length);
+    assertEquals(batchNum * batchSize, rows.length);
     for (int i = 0; i < rows.length; ++i) {
       String[] parts = HiveTestUtils.parseOutput(rows[i]);
-      for (int j = 0; j < expectedResult.get(i).length; ++j) {
-        assertEquals(expectedResult.get(i)[j], parts[j]);
+      int j = 0;
+      for (String expectedValue : expectedResults.get(i)) {
+        assertEquals(expectedValue, parts[j++]);
       }
     }
   }
@@ -294,10 +297,8 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     localProps.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, FieldPartitioner.class.getName());
     localProps.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "country,state");
     setUp();
-
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
 
-    String key = "key";
     Schema schema = SchemaBuilder.struct()
         .field("count", Schema.INT64_SCHEMA)
         .field("country", Schema.STRING_SCHEMA)
@@ -318,16 +319,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
             .put("country", "mx")
             .put("state", null)
     );
-    ArrayList<SinkRecord> sinkRecords = new ArrayList<>();
-    long offset = 0;
-    for (Struct record : records) {
-      for (long count = 0; count < 3; count++) {
-        SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record,
-            offset + count);
-        sinkRecords.add(sinkRecord);
-      }
-      offset = offset + 3;
-    }
+    List<SinkRecord> sinkRecords = createSinkRecords(records, schema);
 
     hdfsWriter.write(sinkRecords);
     hdfsWriter.close();
@@ -339,11 +331,14 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
     }
+    Collections.sort(expectedColumnNames);
 
     List<String> actualColumnNames = new ArrayList<>();
-    for (FieldSchema column : table.getSd().getCols()) {
+    for (FieldSchema column : table.getAllCols()) {
       actualColumnNames.add(column.getName());
     }
+    Collections.sort(actualColumnNames);
+
     assertEquals(expectedColumnNames, actualColumnNames);
 
     String topicsDir = this.topicsDir.get(TOPIC);
@@ -352,32 +347,28 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     expectedPartitions.add(FileUtils.directoryName(url, topicsDir, "test-topic/country=us/state=ca"));
     expectedPartitions.add(FileUtils.directoryName(url, topicsDir, "test-topic/country=us/state=tx"));
 
-    List<String> partitions = hiveMetaStore.listPartitions(hiveDatabase, TOPIC, (short) -1);
+    List<String> partitions = hiveMetaStore.listPartitions(hiveDatabase, TOPIC, (short)-1);
 
     assertEquals(expectedPartitions, partitions);
 
-    List<String[]> expectedResult = Arrays.asList(
-        new String[]{"1", "mx", "NULL"},
-        new String[]{"1", "mx", "NULL"},
-        new String[]{"1", "mx", "NULL"},
-        new String[]{"1", "us", "ca"},
-        new String[]{"1", "us", "ca"},
-        new String[]{"1", "us", "ca"},
-        new String[]{"1", "us", "tx"},
-        new String[]{"1", "us", "tx"},
-        new String[]{"1", "us", "tx"}
+    List<List<String>> expectedResults = Arrays.asList(
+        Arrays.asList("1", "mx", "null"),
+        Arrays.asList("1", "us", "ca"),
+        Arrays.asList("1", "us", "tx")
     );
 
     String result = HiveTestUtils.runHive(
         hiveExec,
-        "SELECT * FROM " + hiveMetaStore.tableNameConverter(TOPIC)
+        "SELECT * FROM " +
+            hiveMetaStore.tableNameConverter(TOPIC)
     );
     String[] rows = result.split("\n");
-    assertEquals(9, rows.length);
+    assertEquals(expectedResults.size(), rows.length);
     for (int i = 0; i < rows.length; ++i) {
       String[] parts = HiveTestUtils.parseOutput(rows[i]);
-      for (int j = 0; j < expectedResult.get(i).length; ++j) {
-        assertEquals(expectedResult.get(i)[j], parts[j]);
+      int j = 0;
+      for (String expectedValue : expectedResults.get(i)) {
+        assertEquals(expectedValue, parts[j++]);
       }
     }
   }

--- a/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
@@ -236,6 +236,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     Collections.sort(expectedColumnNames);
 
     List<String> actualColumnNames = new ArrayList<>();
+    // getAllCols is needed to include columns used for partitioning in result
     for (FieldSchema column : table.getAllCols()) {
       actualColumnNames.add(column.getName());
     }
@@ -334,6 +335,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     Collections.sort(expectedColumnNames);
 
     List<String> actualColumnNames = new ArrayList<>();
+    // getAllCols is needed to include columns used for partitioning in result
     for (FieldSchema column : table.getAllCols()) {
       actualColumnNames.add(column.getName());
     }
@@ -366,9 +368,8 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     assertEquals(expectedResults.size(), rows.length);
     for (int i = 0; i < rows.length; ++i) {
       String[] parts = HiveTestUtils.parseOutput(rows[i]);
-      int j = 0;
-      for (String expectedValue : expectedResults.get(i)) {
-        assertEquals(expectedValue, parts[j++]);
+      for (int j = 0; j < expectedResults.get(i).size(); ++j) {
+        assertEquals(expectedResults.get(i).get(j), parts[j++]);
       }
     }
   }

--- a/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
@@ -175,6 +175,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     Collections.sort(expectedColumnNames);
 
     List<String> actualColumnNames = new ArrayList<>();
+    // getAllCols is needed to include columns used for partitioning in result
     for (FieldSchema column : table.getAllCols()) {
       actualColumnNames.add(column.getName());
     }
@@ -273,6 +274,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     Collections.sort(expectedColumnNames);
 
     List<String> actualColumnNames = new ArrayList<>();
+    // getAllCols is needed to include columns used for partitioning in result
     for (FieldSchema column : table.getAllCols()) {
       actualColumnNames.add(column.getName());
     }

--- a/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.hdfs.parquet;
 
+import java.util.Collections;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.kafka.connect.data.Field;
@@ -149,6 +150,8 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
 
   @Test
   public void testHiveIntegrationFieldPartitionerParquet() throws Exception {
+    int batchSize = 3;
+    int batchNum = 3;
     localProps.put(HiveConfig.HIVE_INTEGRATION_CONFIG, "true");
     localProps.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, FieldPartitioner.class.getName());
     localProps.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "int");
@@ -156,7 +159,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
 
     Schema schema = createSchema();
-    List<Struct> records = createRecordBatches(schema, 3, 3);
+    List<Struct> records = createRecordBatches(schema, batchSize, batchNum);
     List<SinkRecord> sinkRecords = createSinkRecords(records, schema);
 
     hdfsWriter.write(sinkRecords);
@@ -169,11 +172,14 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
     }
+    Collections.sort(expectedColumnNames);
 
     List<String> actualColumnNames = new ArrayList<>();
-    for (FieldSchema column : table.getSd().getCols()) {
+    for (FieldSchema column : table.getAllCols()) {
       actualColumnNames.add(column.getName());
     }
+    Collections.sort(actualColumnNames);
+
     assertEquals(expectedColumnNames, actualColumnNames);
 
     List<String> partitionFieldNames = connectorConfig.getList(
@@ -194,13 +200,17 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
 
     assertEquals(expectedPartitions, partitions);
 
+    Struct sampleRecord = createRecord(schema, 16, 12.2f);
     List<List<String>> expectedResults = new ArrayList<>();
-    for (int i = 0; i < 3; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        List<String> result = new ArrayList<>();
-        for (Field field : schema.fields()) {
-          result.add(String.valueOf(records.get(i).get(field.name())));
-        }
+    for (int batch = 0; batch < batchNum; ++batch) {
+      int intForBatch =  sampleRecord.getInt32("int") + batch;
+      float floatForBatch =  sampleRecord.getFloat32("float") + (float) batch;
+      double doubleForBatch = sampleRecord.getFloat64("double") + (double) batch;
+      for (int row = 0; row < batchSize; ++row) {
+        // the partition field as column is last
+        List<String> result = new ArrayList<>(
+            Arrays.asList("true", String.valueOf(intForBatch), String.valueOf(floatForBatch),
+                String.valueOf(doubleForBatch), String.valueOf(intForBatch)));
         expectedResults.add(result);
       }
     }
@@ -210,7 +220,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
         "SELECT * FROM " + hiveMetaStore.tableNameConverter(TOPIC)
     );
     String[] rows = result.split("\n");
-    assertEquals(9, rows.length);
+    assertEquals(batchNum * batchSize, rows.length);
     for (int i = 0; i < rows.length; ++i) {
       String[] parts = HiveTestUtils.parseOutput(rows[i]);
       int j = 0;
@@ -260,11 +270,14 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     for (Field field : schema.fields()) {
       expectedColumnNames.add(field.name());
     }
+    Collections.sort(expectedColumnNames);
 
     List<String> actualColumnNames = new ArrayList<>();
-    for (FieldSchema column : table.getSd().getCols()) {
+    for (FieldSchema column : table.getAllCols()) {
       actualColumnNames.add(column.getName());
     }
+    Collections.sort(actualColumnNames);
+
     assertEquals(expectedColumnNames, actualColumnNames);
 
     String topicsDir = this.topicsDir.get(TOPIC);
@@ -278,7 +291,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     assertEquals(expectedPartitions, partitions);
 
     List<List<String>> expectedResults = Arrays.asList(
-        Arrays.asList("1", "mx", "NULL"),
+        Arrays.asList("1", "mx", "null"),
         Arrays.asList("1", "us", "ca"),
         Arrays.asList("1", "us", "tx")
     );


### PR DESCRIPTION
## Problem
Duplicate columns are created when the field partitioner is used. 

## Solution
Remove duplicate column instances.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Could not backport to a earlier branch as MiniDFSCluster tests are unstable on older branches.