### PR TITLE
Recover the offset from HDFS, even if topic name is not present in storage path

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -399,7 +399,12 @@ public class DataWriter {
 
     try {
       for (String topic : topics) {
-        String topicDir = FileUtils.topicDirectory(url, topicDirs.get(topic), topic);
+        String topicDir = FileUtils.topicDirectory(
+            url,
+            topicDirs.get(topic),
+            topic,
+            connectorConfig.getBoolean(StorageCommonConfig.PATH_INCLUDE_TOPICNAME_CONFIG)
+        );
         CommittedFileFilter filter = new TopicCommittedFileFilter(topic);
         FileStatus fileStatusWithMaxOffset = FileUtils.fileStatusWithMaxOffset(
             storage,

--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -100,8 +100,21 @@ public class FileUtils {
     return fileName(url, topicsDir, directory, name);
   }
 
+  public static String topicDirectory(String url, String topicsDir) {
+    return url + "/" + topicsDir;
+  }
+
   public static String topicDirectory(String url, String topicsDir, String topic) {
     return url + "/" + topicsDir + "/" + topic;
+  }
+
+  public static String topicDirectory(String url, String topicsDir, String topic,
+      Boolean includeTopicName) {
+    if (includeTopicName) {
+      return topicDirectory(url, topicsDir, topic);
+    } else {
+      return topicDirectory(url, topicsDir);
+    }
   }
 
   public static FileStatus fileStatusWithMaxOffset(

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -53,6 +53,7 @@ import io.confluent.connect.hdfs.partitioner.Partitioner;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.storage.StorageSinkConnectorConfig;
 import io.confluent.connect.storage.hive.HiveConfig;
+import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
 import io.confluent.connect.storage.partitioner.TimestampExtractor;
@@ -338,7 +339,12 @@ public class TopicPartitionWriter {
           case WRITE_PARTITION_PAUSED:
             if (currentSchema == null) {
               if (compatibility != StorageSchemaCompatibility.NONE && offset != -1) {
-                String topicDir = FileUtils.topicDirectory(url, topicsDir, tp.topic());
+                String topicDir = FileUtils.topicDirectory(
+                    url,
+                    topicsDir,
+                    tp.topic(),
+                    connectorConfig.getBoolean(StorageCommonConfig.PATH_INCLUDE_TOPICNAME_CONFIG)
+                );
                 CommittedFileFilter filter = new TopicPartitionCommittedFileFilter(tp);
                 FileStatus fileStatusWithMaxOffset = FileUtils.fileStatusWithMaxOffset(
                     storage,
@@ -422,8 +428,8 @@ public class TopicPartitionWriter {
             // records available
             if (recordCounter == 0 || !shouldRotateAndMaybeUpdateTimers(currentRecord, now)) {
               break;
-            } 
-            
+            }
+
             log.info(
                   "committing files after waiting for rotateIntervalMs time but less than "
                       + "flush.size records available."

--- a/src/test/java/io/confluent/connect/hdfs/FileUtilsTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FileUtilsTest.java
@@ -16,4 +16,10 @@ public class FileUtilsTest {
   public void testExtractOffsetInvalid() {
     assertEquals(1001, FileUtils.extractOffset("namespace+topic+1+1000+1001.avro"));
   }
+
+  @Test
+   public void testTopicDirectories() {
+     assertEquals("hdfs:///topicsDir/topic", FileUtils.topicDirectory("hdfs://", "topicsDir", "topic", true));
+     assertEquals("hdfs:///topicsDir", FileUtils.topicDirectory("hdfs://", "topicsDir", "topic", false));
+   }
 }

--- a/src/test/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitionerTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/partitioner/TimeBasedPartitionerTest.java
@@ -66,6 +66,7 @@ public class TimeBasedPartitionerTest extends HdfsSinkConnectorTestBase {
 
     @Override
     public void configure(Map<String, Object> config) {
+      super.configure(config);
       init(partitionDurationMs, pathFormat, Locale.FRENCH, DATE_TIME_ZONE, config);
     }
 


### PR DESCRIPTION
## Problem
Exactly-once semantics should also work without topic name included in the path.

## Solution
The function that recover offsets from file names will use the correct path by taking into account a new configuration flag `path_include_topicname ` introduced with confluentinc/kafka-connect-storage-common#126.

Further, the backward compatibility of appending the topic name is retained by default value `true` for `path_include_topicname`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
This change is necessary to retain EOS semantics to support flexible storage partitioning scheme as proposed here: confluentinc/kafka-connect-storage-common#126

## Test Strategy
<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
