### PR TITLE
Import CVE-free htrace-core4 and avatica from kafka-connect-storage-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j-api.version>2.8.2</log4j-api.version>
+        <htrace-core4.version>10.0.0-SNAPSHOT</htrace-core4.version>
+        <avatica.version>10.0.0-SNAPSHOT</avatica.version>
     </properties>
 
     <repositories>
@@ -121,6 +123,14 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.calcite.avatica</groupId>
+                    <artifactId>avatica</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -145,6 +155,16 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
+            <version>${htrace-core4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-common-avatica-shaded</artifactId>
+            <version>${avatica.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -181,6 +201,10 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,10 @@
                     <artifactId>htrace-core4</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.calcite.avatica</groupId>
                     <artifactId>avatica</artifactId>
                 </exclusion>
@@ -183,6 +187,10 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,10 @@
                     <groupId>org.apache.calcite.avatica</groupId>
                     <artifactId>avatica</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro-ipc-jetty</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>10.0.0</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -56,13 +56,13 @@
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>10.0.0-SNAPSHOT</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>10.0.0</kafka.connect.storage.common.version>
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j-api.version>2.8.2</log4j-api.version>
-        <htrace-core4.version>10.0.0-SNAPSHOT</htrace-core4.version>
-        <avatica.version>10.0.0-SNAPSHOT</avatica.version>
+        <htrace-core4.version>10.0.0</htrace-core4.version>
+        <avatica.version>10.0.0</avatica.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Problem
Some dependencies bring shaded jackson with them. And these jackson versions are older and have CVEs

## Solution
We reshaded the dependencies in storage-common. This PR uses these jars instead and we are also using the recently released 10.0.0 of storage-common for that purpose. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
10.0.0 of hdfs will be released soon after we merge here. 