### PR TITLE
Fix the data loss problem

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -406,6 +406,7 @@ public class TopicPartitionWriter {
         throw new RuntimeException(e);
       } catch (ConnectException e) {
         log.error("Exception on topic partition {}: ", tp, e);
+        context.offset(tp, offset);
         failureTime = time.milliseconds();
         setRetryTimeout(timeoutMs);
         break;


### PR DESCRIPTION
## Problem
When HDFS fails, the data being written will be lost.

## Solution
 it is necessary to record the offset. When HDFS is recovered, the offset will be reset and rewind to ensure that the data is not lost.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
