### PR TITLE
CC-13111: fix Kerberos tests interfering with non-Kerberos tests

### DIFF
--- a/src/test/java/io/confluent/connect/hdfs/TestWithSecureMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithSecureMiniDFSCluster.java
@@ -17,8 +17,10 @@ package io.confluent.connect.hdfs;
 
 import io.confluent.connect.storage.common.StorageCommonConfig;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.http.HttpConfig;
@@ -28,7 +30,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.File;
@@ -53,6 +54,8 @@ import static org.junit.Assert.assertTrue;
 public class TestWithSecureMiniDFSCluster extends HdfsSinkConnectorTestBase {
 
   private static File baseDir;
+  private static FileSystem fs;
+  private static MiniDFSCluster cluster;
   private static String hdfsPrincipal;
   private static MiniKdc kdc;
   private static String keytab;
@@ -60,11 +63,27 @@ public class TestWithSecureMiniDFSCluster extends HdfsSinkConnectorTestBase {
   private static String connectorPrincipal;
   private static String connectorKeytab;
 
-  private MiniDFSCluster cluster;
-  private FileSystem fs;
-
   @BeforeClass
-  public static void initKdc() throws Exception {
+  public static void setup() throws Exception {
+    initKdc();
+
+    cluster = createDFSCluster();
+    fs = cluster.getFileSystem();
+  }
+
+  @AfterClass
+  public static void cleanup() throws IOException {
+    if (fs != null) {
+      fs.close();
+    }
+    if (cluster != null) {
+      cluster.shutdown(true);
+    }
+    UserGroupInformation.reset();
+    shutdownKdc();
+  }
+
+  private static void initKdc() throws Exception {
     baseDir = new File(System.getProperty("test.build.dir", "target/test-dir"));
     FileUtil.fullyDelete(baseDir);
     assertTrue(baseDir.mkdirs());
@@ -84,8 +103,7 @@ public class TestWithSecureMiniDFSCluster extends HdfsSinkConnectorTestBase {
     connectorPrincipal = "connect-hdfs/localhost@" + kdc.getRealm();
   }
 
-  @AfterClass
-  public static void shutdownKdc() {
+  private static void shutdownKdc() {
     if (kdc != null) {
       kdc.stop();
     }
@@ -94,10 +112,6 @@ public class TestWithSecureMiniDFSCluster extends HdfsSinkConnectorTestBase {
 
   //@Before should be omitted in order to be able to add properties per test.
   public void setUp() throws Exception {
-    conf = createSecureConfig("authentication");
-    cluster = createDFSCluster(conf);
-    cluster.waitActive();
-    fs = cluster.getFileSystem();
     Map<String, String> props = createProps();
     connectorConfig = new HdfsSinkConnectorConfig(props);
     super.setUp();
@@ -105,26 +119,18 @@ public class TestWithSecureMiniDFSCluster extends HdfsSinkConnectorTestBase {
 
   @After
   public void tearDown() throws Exception {
-    if (fs != null) {
-      fs.close();
+    if (fs.exists(new Path("/")) && fs.isDirectory(new Path("/"))) {
+      for (FileStatus file : fs.listStatus(new Path("/"))) {
+        if (file.isDirectory()) {
+          fs.delete(file.getPath(), true);
+        } else {
+          fs.delete(file.getPath(), false);
+        }
+      }
     }
-    if (cluster != null) {
-      cluster.shutdown(true);
-    }
-    super.tearDown();
   }
 
-  private MiniDFSCluster createDFSCluster(Configuration conf) throws IOException {
-    MiniDFSCluster cluster;
-    String[] hosts = {"localhost", "localhost", "localhost"};
-    MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
-    builder.hosts(hosts).nameNodePort(9001).numDataNodes(3);
-    cluster = builder.build();
-    cluster.waitActive();
-    return cluster;
-  }
-
-  private Configuration createSecureConfig(String dataTransferProtection) throws Exception {
+  private static Configuration createSecureConfig(String dataTransferProtection) throws Exception {
     HdfsConfiguration conf = new HdfsConfiguration();
     SecurityUtil.setAuthenticationMethod(UserGroupInformation.AuthenticationMethod.KERBEROS, conf);
     conf.set(DFS_NAMENODE_KERBEROS_PRINCIPAL_KEY, hdfsPrincipal);
@@ -141,7 +147,7 @@ public class TestWithSecureMiniDFSCluster extends HdfsSinkConnectorTestBase {
     conf.set(DFS_ENCRYPT_DATA_TRANSFER_KEY,
              "true");//https://issues.apache.org/jira/browse/HDFS-7431
     String keystoresDir = baseDir.getAbsolutePath();
-    String sslConfDir = KeyStoreTestUtil.getClasspathDir(this.getClass());
+    String sslConfDir = KeyStoreTestUtil.getClasspathDir(TestWithSecureMiniDFSCluster.class);
     KeyStoreTestUtil.setupSSLConfig(keystoresDir, sslConfDir, conf, false);
     return conf;
   }
@@ -163,5 +169,17 @@ public class TestWithSecureMiniDFSCluster extends HdfsSinkConnectorTestBase {
     props.put(HdfsSinkConnectorConfig.CONNECT_HDFS_KEYTAB_CONFIG, keytab);
     props.put(HdfsSinkConnectorConfig.HDFS_NAMENODE_PRINCIPAL_CONFIG, hdfsPrincipal);
     return props;
+  }
+
+  private static MiniDFSCluster createDFSCluster() throws Exception {
+    MiniDFSCluster cluster = new MiniDFSCluster
+        .Builder(createSecureConfig("authentication"))
+        .hosts(new String[]{"localhost", "localhost", "localhost"})
+        .nameNodePort(9001)
+        .numDataNodes(3)
+        .build();
+    cluster.waitActive();
+
+    return cluster;
   }
 }


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
when running all the tests together in Intellij the Kerberos tests interfere with the non-Kerberos tests and cause them fail because the UserGroupInformation is set by the connector and that is a static instance

## Solution
reset the UGI between each test
bonus: refactored the tests to take 30 seconds down from 7 minutes by reusing a HDFS instance for each test

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
HDFS3 has the same issue

## Test Strategy
run all previous tests and make sure they are green when run simultaneously 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
`10.0.x` is earliest because `reset()` isn't provided in earlier Hadoop versions