### PR TITLE
CCMSG-857: Match lease acquisition log level

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -82,7 +82,7 @@ public class FSWAL implements WAL {
         break;
       } catch (RemoteException e) {
         if (e.getClassName().equals(WALConstants.LEASE_EXCEPTION_CLASS_NAME)) {
-          log.info(
+          log.warn(
               "Cannot acquire lease on WAL, {}-{}, file {}",
               conf.getName(),
               conf.getTaskId(),

--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -179,7 +179,7 @@ public class WALFile {
 
         init(connectorConfig, out, ownStream);
       } catch (RemoteException re) {
-        log.error("Failed creating a WAL Writer: " + re.getMessage());
+        log.warn("Failed creating a WAL Writer: " + re.getMessage());
         if (fs != null) {
           try {
             fs.close();


### PR DESCRIPTION
## Problem

```
09:28:12.741 [task-thread-ConnectorName-0] ERROR io.confluent.connect.hdfs.wal.WALFile - Failed creating a WAL Writer: Failed to APPEND_FILE /abc/4/log for DFSClient on 10.10.10.10 because this file lease is currently owned by DFSClient on 10.10.10.11
[2021-02-01 09:28:12,741] INFO Cannot acquire lease on WAL, ConnectorName-0, file hdfs://abc/4/log (io.confluent.connect.hdfs.wal.FSWAL)
```

The error message above (on not being able to acquire a lease) is expected when one task is waiting for another task to release the `WAL` file. Both messages refer to the same issue, but are logged at different log levels. 

## Solution
Both messages should be logged on the same level, and not `ERROR` level as this is an expected behavior when leases are held. An exception is thrown later if there is a retry timeout on acquiring the lease, so these messages are safe to log on a higher level than `ERROR`.  

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backporting to `5.0.x`, earliest branch where updated logs appear. 