### PR TITLE
MINOR: add getters for hdfs configs

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -295,7 +295,6 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     return configDef;
   }
 
-  private final String name;
   private final String url;
   private final StorageCommonConfig commonConfig;
   private final HiveConfig hiveConfig;
@@ -316,7 +315,6 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     hiveConfig = new HiveConfig(originalsStrings());
     ConfigDef partitionerConfigDef = PartitionerConfig.newConfigDef(PARTITIONER_CLASS_RECOMMENDER);
     partitionerConfig = new PartitionerConfig(partitionerConfigDef, originalsStrings());
-    this.name = parseName(originalsStrings());
     this.hadoopConfig = new Configuration();
     taskId = props.get(TASK_ID_CONFIG_NAME) != null
         ? Integer.parseInt(props.get(TASK_ID_CONFIG_NAME)) : -1;
@@ -353,11 +351,6 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     return propsCopy;
   }
 
-  protected static String parseName(Map<String, String> props) {
-    String nameProp = props.get("name");
-    return nameProp != null ? nameProp : "HDFS-sink";
-  }
-
   private void addToGlobal(AbstractConfig config) {
     allConfigs.add(config);
     addConfig(config.values(), (ComposableConfig) config);
@@ -391,11 +384,43 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     );
   }
 
-  public String getName() {
-    return name;
+  public String connectHdfsPrincipal() {
+    return getString(CONNECT_HDFS_PRINCIPAL_CONFIG);
   }
 
-  public String getUrl() {
+  public String connectHdfsKeytab() {
+    return getString(CONNECT_HDFS_KEYTAB_CONFIG);
+  }
+
+  public String hadoopConfDir() {
+    return getString(HADOOP_CONF_DIR_CONFIG);
+  }
+
+  public String hadoopHome() {
+    return getString(HADOOP_HOME_CONFIG);
+  }
+
+  public String hdfsNamenodePrincipal() {
+    return getString(HDFS_NAMENODE_PRINCIPAL_CONFIG);
+  }
+
+  public boolean kerberosAuthentication() {
+    return getBoolean(HDFS_AUTHENTICATION_KERBEROS_CONFIG);
+  }
+
+  public long kerberosTicketRenewPeriodMs() {
+    return getLong(KERBEROS_TICKET_RENEW_PERIOD_MS_CONFIG);
+  }
+
+  public String logsDir() {
+    return getString(LOGS_DIR_CONFIG);
+  }
+
+  public String name() {
+    return originalsStrings().getOrDefault("name", "HDFS-sink");
+  }
+
+  public String url() {
     return url;
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -151,7 +151,7 @@ public class TopicPartitionWriter {
       io.confluent.connect.storage.format.RecordWriterProvider<HdfsSinkConnectorConfig>
           newWriterProvider,
       Partitioner partitioner,
-      HdfsSinkConnectorConfig connectorConfig,
+      HdfsSinkConnectorConfig config,
       SinkTaskContext context,
       AvroData avroData,
       HiveMetaStore hiveMetaStore,
@@ -186,17 +186,16 @@ public class TopicPartitionWriter {
     this.connectorConfig = storage.conf();
     this.schemaFileReader = schemaFileReader;
 
-    topicsDir = connectorConfig.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
-    flushSize = connectorConfig.getInt(HdfsSinkConnectorConfig.FLUSH_SIZE_CONFIG);
-    rotateIntervalMs = connectorConfig.getLong(HdfsSinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG);
-    rotateScheduleIntervalMs = connectorConfig.getLong(HdfsSinkConnectorConfig
+    topicsDir = config.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
+    flushSize = config.getInt(HdfsSinkConnectorConfig.FLUSH_SIZE_CONFIG);
+    rotateIntervalMs = config.getLong(HdfsSinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG);
+    rotateScheduleIntervalMs = config.getLong(HdfsSinkConnectorConfig
         .ROTATE_SCHEDULE_INTERVAL_MS_CONFIG);
-    timeoutMs = connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG);
+    timeoutMs = config.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG);
     compatibility = StorageSchemaCompatibility.getCompatibility(
-        connectorConfig.getString(HiveConfig.SCHEMA_COMPATIBILITY_CONFIG));
+        config.getString(HiveConfig.SCHEMA_COMPATIBILITY_CONFIG));
 
-    String logsDir = connectorConfig.getString(HdfsSinkConnectorConfig.LOGS_DIR_CONFIG);
-    wal = storage.wal(logsDir, tp);
+    wal = storage.wal(config.logsDir(), tp);
 
     buffer = new LinkedList<>();
     writers = new HashMap<>();
@@ -218,12 +217,12 @@ public class TopicPartitionWriter {
       );
     }
     zeroPadOffsetFormat = "%0"
-        + connectorConfig.getInt(HdfsSinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG)
+        + config.getInt(HdfsSinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG)
         + "d";
 
-    hiveIntegration = connectorConfig.getBoolean(HiveConfig.HIVE_INTEGRATION_CONFIG);
+    hiveIntegration = config.getBoolean(HiveConfig.HIVE_INTEGRATION_CONFIG);
     if (hiveIntegration) {
-      hiveDatabase = connectorConfig.getString(HiveConfig.HIVE_DATABASE_CONFIG);
+      hiveDatabase = config.getString(HiveConfig.HIVE_DATABASE_CONFIG);
     } else {
       hiveDatabase = null;
     }
@@ -235,7 +234,7 @@ public class TopicPartitionWriter {
     hivePartitions = new HashSet<>();
 
     if (rotateScheduleIntervalMs > 0) {
-      timeZone = DateTimeZone.forID(connectorConfig.getString(PartitionerConfig.TIMEZONE_CONFIG));
+      timeZone = DateTimeZone.forID(config.getString(PartitionerConfig.TIMEZONE_CONFIG));
     } else {
       timeZone = null;
     }

--- a/src/main/java/io/confluent/connect/hdfs/hive/HiveUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/hive/HiveUtil.java
@@ -28,7 +28,7 @@ public abstract class HiveUtil extends io.confluent.connect.storage.hive.HiveUti
 
   public HiveUtil(HdfsSinkConnectorConfig connectorConfig, HiveMetaStore hiveMetaStore) {
     super(connectorConfig, hiveMetaStore);
-    this.url = connectorConfig.getUrl();
+    this.url = connectorConfig.url();
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -74,7 +74,7 @@ public class FSWAL implements WAL {
                                         Writer.appendIfExists(true));
           log.info(
               "Successfully acquired lease, {}-{}, file {}",
-              conf.getName(),
+              conf.name(),
               conf.getTaskId(),
               logFile
           );
@@ -84,7 +84,7 @@ public class FSWAL implements WAL {
         if (e.getClassName().equals(WALConstants.LEASE_EXCEPTION_CLASS_NAME)) {
           log.warn(
               "Cannot acquire lease on WAL, {}-{}, file {}",
-              conf.getName(),
+              conf.name(),
               conf.getTaskId(),
               logFile
           );
@@ -101,7 +101,7 @@ public class FSWAL implements WAL {
         throw new DataException(
             String.format(
                 "Error creating writer for log file, %s-%s, file %s",
-                conf.getName(),
+                conf.name(),
                 conf.getTaskId(),
                 logFile
             ),
@@ -170,7 +170,7 @@ public class FSWAL implements WAL {
   public void close() throws ConnectException {
     log.info(
         "Closing WAL, {}-{}, file: {}",
-        conf.getName(),
+        conf.name(),
         conf.getTaskId(),
         logFile
     );

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
@@ -65,14 +65,14 @@ public class HdfsSinkConnectorConfigTest extends TestWithMiniDFSCluster {
   @Test
   public void testStorageCommonUrlPreferred() {
     connectorConfig = new HdfsSinkConnectorConfig(properties);
-    assertEquals(url, connectorConfig.getUrl());
+    assertEquals(url, connectorConfig.url());
   }
 
   @Test
   public void testHdfsUrlIsValid() {
     connectorConfig = new HdfsSinkConnectorConfig(properties);
     properties.remove(StorageCommonConfig.STORE_URL_CONFIG);
-    assertEquals(url, connectorConfig.getUrl());
+    assertEquals(url, connectorConfig.url());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorTestBase.java
@@ -33,7 +33,6 @@ import io.confluent.connect.hdfs.avro.AvroFormat;
 import io.confluent.connect.hdfs.partitioner.DefaultPartitioner;
 import io.confluent.connect.storage.StorageSinkTestBase;
 import io.confluent.connect.storage.common.StorageCommonConfig;
-import io.confluent.connect.storage.hive.schema.DefaultSchemaGenerator;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
 public class HdfsSinkConnectorTestBase extends StorageSinkTestBase {
@@ -115,7 +114,7 @@ public class HdfsSinkConnectorTestBase extends StorageSinkTestBase {
     parsedConfig = new HashMap<>(connectorConfig.plainValues());
     conf = connectorConfig.getHadoopConfiguration();
     topicsDir = connectorConfig.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
-    logsDir = connectorConfig.getString(HdfsSinkConnectorConfig.LOGS_DIR_CONFIG);
+    logsDir = connectorConfig.logsDir();
     avroData = new AvroData(connectorConfig.avroDataConfig());
   }
 


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
HDFS connector uses an outdated approach of fetching the configs directly

## Solution
replace with getters for readability 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
storage common

## Test Strategy
run existing tests to ensure no regressions

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.0.x` to remove merge conflicts