### PR TITLE
Support N topics written under the same directory

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -399,7 +399,8 @@ public class DataWriter {
 
     try {
       for (String topic : topics) {
-        String topicDir = FileUtils.topicDirectory(url, topicDirs.get(topic), topic);
+        String topicDir = FileUtils
+            .topicDataRootDirectory(url, topicDirs.get(topic), topic, partitioner);
         CommittedFileFilter filter = new TopicCommittedFileFilter(topic);
         FileStatus fileStatusWithMaxOffset = FileUtils.fileStatusWithMaxOffset(
             storage,

--- a/src/test/java/io/confluent/connect/hdfs/FileUtilsTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FileUtilsTest.java
@@ -2,6 +2,7 @@ package io.confluent.connect.hdfs;
 
 import static org.junit.Assert.assertEquals;
 
+import io.confluent.connect.hdfs.partitioner.DefaultPartitioner;
 import org.junit.Test;
 
 public class FileUtilsTest {
@@ -15,5 +16,32 @@ public class FileUtilsTest {
   @Test(expected = IllegalArgumentException.class)
   public void testExtractOffsetInvalid() {
     assertEquals(1001, FileUtils.extractOffset("namespace+topic+1+1000+1001.avro"));
+  }
+
+  @Test
+  public void testTopicDataRootDirectory() {
+
+    String url = "hdfs://localhost";
+    String topicsDir = "kafka_data";
+    String topic = "topic-a";
+
+    assertEquals(
+        url + "/" + topicsDir + "/" + topic,
+        FileUtils.topicDataRootDirectory(url, topicsDir, topic, new DefaultPartitioner()));
+
+    assertEquals(
+        url + "/" + topicsDir,
+        FileUtils.topicDataRootDirectory(url, topicsDir, topic, new CustomPathPartitioner()));
+
+  }
+
+  private static class CustomPathPartitioner extends DefaultPartitioner {
+
+    static final String DIR = "custom_all_topics_dir";
+
+    @Override
+    public String generatePartitionedPath(String topic, String encodedPartition) {
+      return DIR + this.delim + encodedPartition;
+    }
   }
 }


### PR DESCRIPTION
## Problem

When using a custom partitioner, one can opt out from having topic data separated into topic specific directory. But when writing data from N topics under the same directory, the recovery of offsets is looking for files under paths which does not exists. 

## Solution

Detect if partitioner us adding topic name to the output path. If not, exclude it from the search path for committed files -> start search from parent directory. This however does not cover generic case when partitioner chooses some exotic path strategy.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
