### PR TITLE
MINOR: Refactor code for readability and add improved logging

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -111,115 +111,71 @@ public class DataWriter {
       Time time
   ) {
     this.time = time;
+    this.connectorConfig = config;
+    this.avroData = avroData;
+    this.context = context;
+    url = config.url();
+    topicDirs = new HashMap<>();
+    logDirs = new HashMap<>();
+    hiveIntegration = config.getBoolean(HiveConfig.HIVE_INTEGRATION_CONFIG);
+    topicPartitionWriters = new HashMap<>();
+
     try {
-      System.setProperty("hadoop.home.dir", config.hadoopHome());
-
-      this.connectorConfig = config;
-      this.avroData = avroData;
-      this.context = context;
-
-      log.info("Hadoop configuration directory {}", config.hadoopConfDir());
-      Configuration conf = config.getHadoopConfiguration();
-      if (!config.hadoopConfDir().equals("")) {
-        conf.addResource(new Path(config.hadoopConfDir() + "/core-site.xml"));
-        conf.addResource(new Path(config.hadoopConfDir() + "/hdfs-site.xml"));
-      }
-
-      if (config.kerberosAuthentication()) {
-        SecurityUtil.setAuthenticationMethod(
-            UserGroupInformation.AuthenticationMethod.KERBEROS,
-            conf
-        );
-
-        if (config.connectHdfsPrincipal() == null || config.connectHdfsKeytab() == null) {
-          throw new ConfigException(
-              "Hadoop is using Kerberos for authentication, you need to provide both a connect "
-                  + "principal and the path to the keytab of the principal.");
-        }
-
-        conf.set("hadoop.security.authentication", "kerberos");
-        conf.set("hadoop.security.authorization", "true");
-        String hostname = InetAddress.getLocalHost().getCanonicalHostName();
-
-        String namenodePrincipal = SecurityUtil.getServerPrincipal(
-            config.hdfsNamenodePrincipal(),
-            hostname
-        );
-        // namenode principal is needed for multi-node hadoop cluster
-        if (conf.get("dfs.namenode.kerberos.principal") == null) {
-          conf.set("dfs.namenode.kerberos.principal", namenodePrincipal);
-        }
-        log.info("Hadoop namenode principal: " + conf.get("dfs.namenode.kerberos.principal"));
-
-        UserGroupInformation.setConfiguration(conf);
-        // replace the _HOST specified in the principal config to the actual host
-        String principal = SecurityUtil.getServerPrincipal(config.connectHdfsPrincipal(), hostname);
-        UserGroupInformation.loginUserFromKeytab(principal, config.connectHdfsKeytab());
-        final UserGroupInformation ugi = UserGroupInformation.getLoginUser();
-        log.info("Login as: " + ugi.getUserName());
-
-        isRunning = true;
-        ticketRenewThread = new Thread(new Runnable() {
-          @Override
-          public void run() {
-            synchronized (DataWriter.this) {
-              while (isRunning) {
-                try {
-                  DataWriter.this.wait(config.kerberosTicketRenewPeriodMs());
-                  if (isRunning) {
-                    ugi.reloginFromKeytab();
-                  }
-                } catch (IOException e) {
-                  // We ignore this exception during relogin as each successful relogin gives
-                  // additional 24 hours of authentication in the default config. In normal
-                  // situations, the probability of failing relogin 24 times is low and if
-                  // that happens, the task will fail eventually.
-                  log.error("Error renewing the ticket", e);
-                } catch (InterruptedException e) {
-                  // ignored
-                }
-              }
-            }
-          }
-        });
-        log.info(
-            "Starting the Kerberos ticket renew thread with period {} ms.",
-            config.kerberosTicketRenewPeriodMs()
-        );
-        ticketRenewThread.start();
-      }
-
-      url = config.url();
-
-      @SuppressWarnings("unchecked")
-      Class<? extends HdfsStorage> storageClass = (Class<? extends HdfsStorage>) config
-          .getClass(StorageCommonConfig.STORAGE_CLASS_CONFIG);
-      storage = io.confluent.connect.storage.StorageFactory.createStorage(
-          storageClass,
-          HdfsSinkConnectorConfig.class,
-          config,
-          url
+      partitioner = newPartitioner(config);
+    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+      throw new ConnectException(
+          String.format("Unable to initialize partitioner: %s", e.getMessage()),
+          e
       );
+    }
 
-      topicDirs = new HashMap<>();
-      for (TopicPartition tp : context.assignment()) {
-        topicDirs.computeIfAbsent(tp.topic(), top -> connectorConfig.getTopicsDirFromTopic(top));
+    System.setProperty("hadoop.home.dir", config.hadoopHome());
+    log.info("Hadoop configuration directory {}", config.hadoopConfDir());
+    Configuration hadoopConfiguration = config.getHadoopConfiguration();
+    if (!config.hadoopConfDir().equals("")) {
+      hadoopConfiguration.addResource(new Path(config.hadoopConfDir() + "/core-site.xml"));
+      hadoopConfiguration.addResource(new Path(config.hadoopConfDir() + "/hdfs-site.xml"));
+    }
+
+    if (config.kerberosAuthentication()) {
+      try {
+        configureKerberosAuthentication(hadoopConfiguration);
+      } catch (IOException e) {
+        throw new ConnectException(
+            String.format("Could not authenticate with Kerberos: %s", e.getMessage()),
+            e
+        );
       }
+    }
 
-      for (String directory : topicDirs.values()) {
-        createDir(directory);
-        createDir(directory + HdfsSinkConnectorConstants.TEMPFILE_DIRECTORY);
-      }
+    @SuppressWarnings("unchecked")
+    Class<? extends HdfsStorage> storageClass = (Class<? extends HdfsStorage>) config
+        .getClass(StorageCommonConfig.STORAGE_CLASS_CONFIG);
+    storage = io.confluent.connect.storage.StorageFactory.createStorage(
+        storageClass,
+        HdfsSinkConnectorConfig.class,
+        config,
+        url
+    );
 
-      logDirs = new HashMap<>();
-      for (TopicPartition tp : context.assignment()) {
-        logDirs.computeIfAbsent(tp.topic(), topic -> connectorConfig.getLogsDirFromTopic(topic));
-      }
+    for (TopicPartition tp : context.assignment()) {
+      topicDirs.computeIfAbsent(tp.topic(), top -> connectorConfig.getTopicsDirFromTopic(top));
+    }
 
-      for (String directory : logDirs.values()) {
-        createDir(directory);
-      }
+    for (String directory : topicDirs.values()) {
+      createDir(directory);
+      createDir(directory + HdfsSinkConnectorConstants.TEMPFILE_DIRECTORY);
+    }
 
+    for (TopicPartition tp : context.assignment()) {
+      logDirs.computeIfAbsent(tp.topic(), topic -> connectorConfig.getLogsDirFromTopic(topic));
+    }
+
+    for (String directory : logDirs.values()) {
+      createDir(directory);
+    }
+
+    try {
       // Try to instantiate as a new-style storage-common type class, then fall back to old-style
       // with no parameters
       try {
@@ -273,68 +229,143 @@ public class DataWriter {
         };
       }
 
-      partitioner = newPartitioner(config);
-
-      hiveIntegration = config.getBoolean(HiveConfig.HIVE_INTEGRATION_CONFIG);
-      if (hiveIntegration) {
-        hiveDatabase = config.getString(HiveConfig.HIVE_DATABASE_CONFIG);
-        hiveMetaStore = new HiveMetaStore(conf, config);
-        if (format != null) {
-          hive = format.getHiveUtil(config, hiveMetaStore);
-        } else if (newFormat != null) {
-          final io.confluent.connect.storage.hive.HiveUtil newHiveUtil
-              = ((HiveFactory) newFormat.getHiveFactory())
-              .createHiveUtil(connectorConfig, hiveMetaStore);
-          hive = new HiveUtil(connectorConfig, hiveMetaStore) {
-            @Override
-            public void createTable(
-                String database, String tableName, Schema schema,
-                Partitioner partitioner
-            ) {
-              newHiveUtil.createTable(database, tableName, schema, partitioner);
-            }
-
-            @Override
-            public void alterSchema(String database, String tableName, Schema schema) {
-              newHiveUtil.alterSchema(database, tableName, schema);
-            }
-          };
-        } else {
-          throw new ConnectException("One of old or new format classes must be provided");
-        }
-        executorService = Executors.newSingleThreadExecutor();
-        hiveUpdateFutures = new LinkedList<>();
-      }
-
-      topicPartitionWriters = new HashMap<>();
-      for (TopicPartition tp : context.assignment()) {
-        TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-            tp,
-            storage,
-            writerProvider,
-            newWriterProvider,
-            partitioner,
-            config,
-            context,
-            avroData,
-            hiveMetaStore,
-            hive,
-            schemaFileReader,
-            executorService,
-            hiveUpdateFutures,
-            time
-        );
-        topicPartitionWriters.put(tp, topicPartitionWriter);
-      }
-    } catch (ClassNotFoundException
-            | IllegalAccessException
-            | InstantiationException
-            | InvocationTargetException
-            | NoSuchMethodException e
+    } catch (IllegalAccessException
+              | InstantiationException
+              | InvocationTargetException
+              | NoSuchMethodException e
     ) {
       throw new ConnectException("Reflection exception: ", e);
-    } catch (IOException e) {
-      throw new ConnectException(e);
+    }
+
+    if (hiveIntegration) {
+      initializeHiveServices(hadoopConfiguration);
+    }
+
+    initializeTopicPartitionWriters(context.assignment());
+  }
+
+  private void configureKerberosAuthentication(Configuration hadoopConfiguration)
+      throws IOException {
+    SecurityUtil.setAuthenticationMethod(
+        UserGroupInformation.AuthenticationMethod.KERBEROS,
+        hadoopConfiguration
+    );
+
+    if (connectorConfig.connectHdfsPrincipal() == null
+        || connectorConfig.connectHdfsKeytab() == null) {
+      throw new ConfigException(
+          "Hadoop is using Kerberos for authentication, you need to provide both a connect "
+              + "principal and the path to the keytab of the principal.");
+    }
+
+    hadoopConfiguration.set("hadoop.security.authentication", "kerberos");
+    hadoopConfiguration.set("hadoop.security.authorization", "true");
+    String hostname = InetAddress.getLocalHost().getCanonicalHostName();
+
+    String namenodePrincipal = SecurityUtil.getServerPrincipal(
+        connectorConfig.hdfsNamenodePrincipal(),
+        hostname
+    );
+    // namenode principal is needed for multi-node hadoop cluster
+    if (hadoopConfiguration.get("dfs.namenode.kerberos.principal") == null) {
+      hadoopConfiguration.set("dfs.namenode.kerberos.principal", namenodePrincipal);
+    }
+    log.info("Hadoop namenode principal: {}",
+        hadoopConfiguration.get("dfs.namenode.kerberos.principal"));
+
+    UserGroupInformation.setConfiguration(hadoopConfiguration);
+    // replace the _HOST specified in the principal config to the actual host
+    String principal = SecurityUtil.getServerPrincipal(
+        connectorConfig.connectHdfsPrincipal(),
+        hostname
+    );
+    UserGroupInformation.loginUserFromKeytab(principal, connectorConfig.connectHdfsKeytab());
+    final UserGroupInformation ugi = UserGroupInformation.getLoginUser();
+    log.info("Login as: " + ugi.getUserName());
+
+    isRunning = true;
+    ticketRenewThread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        synchronized (DataWriter.this) {
+          while (isRunning) {
+            try {
+              DataWriter.this.wait(connectorConfig.kerberosTicketRenewPeriodMs());
+              if (isRunning) {
+                log.debug("Attempting re-login from keytab for user: {}", ugi.getUserName());
+                ugi.reloginFromKeytab();
+              }
+            } catch (IOException e) {
+              // We ignore this exception during relogin as each successful relogin gives
+              // additional 24 hours of authentication in the default config. In normal
+              // situations, the probability of failing relogin 24 times is low and if
+              // that happens, the task will fail eventually.
+              log.error("Error renewing the ticket", e);
+            } catch (InterruptedException e) {
+              // ignored
+            }
+          }
+        }
+      }
+    });
+    log.info(
+        "Starting the Kerberos ticket renew thread with period {} ms.",
+        connectorConfig.kerberosTicketRenewPeriodMs()
+    );
+    ticketRenewThread.start();
+  }
+
+  private void initializeHiveServices(Configuration hadoopConfiguration) {
+    hiveDatabase = connectorConfig.getString(HiveConfig.HIVE_DATABASE_CONFIG);
+    hiveMetaStore = new HiveMetaStore(hadoopConfiguration, connectorConfig);
+    if (format != null) {
+      hive = format.getHiveUtil(connectorConfig, hiveMetaStore);
+    } else if (newFormat != null) {
+      final io.confluent.connect.storage.hive.HiveUtil newHiveUtil
+          = ((HiveFactory) newFormat.getHiveFactory())
+          .createHiveUtil(connectorConfig, hiveMetaStore);
+      hive = new HiveUtil(connectorConfig, hiveMetaStore) {
+        @Override
+        public void createTable(
+            String database, String tableName, Schema schema,
+            Partitioner partitioner
+        ) {
+          newHiveUtil.createTable(database, tableName, schema, partitioner);
+          log.debug("Created Hive table {}", tableName);
+        }
+
+        @Override
+        public void alterSchema(String database, String tableName, Schema schema) {
+          newHiveUtil.alterSchema(database, tableName, schema);
+          log.debug("Altered Hive table {}", tableName);
+        }
+      };
+    } else {
+      throw new ConnectException("One of old or new format classes must be provided");
+    }
+    executorService = Executors.newSingleThreadExecutor();
+    hiveUpdateFutures = new LinkedList<>();
+  }
+
+  private void initializeTopicPartitionWriters(Set<TopicPartition> assignment) {
+    for (TopicPartition tp : assignment) {
+      TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+          tp,
+          storage,
+          writerProvider,
+          newWriterProvider,
+          partitioner,
+          connectorConfig,
+          context,
+          avroData,
+          hiveMetaStore,
+          hive,
+          schemaFileReader,
+          executorService,
+          hiveUpdateFutures,
+          time
+      );
+      topicPartitionWriters.put(tp, topicPartitionWriter);
     }
   }
 
@@ -540,6 +571,7 @@ public class DataWriter {
   private void createDir(String dir) {
     String path = url + "/" + dir;
     if (!storage.exists(path)) {
+      log.trace("Creating directory {}", path);
       storage.create(path);
     }
   }

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -65,6 +65,8 @@ import static io.confluent.connect.storage.common.StorageCommonConfig.TOPICS_DIR
 import static io.confluent.connect.storage.common.StorageCommonConfig.TOPICS_DIR_DEFAULT;
 import static io.confluent.connect.storage.common.StorageCommonConfig.TOPICS_DIR_DISPLAY;
 import static io.confluent.connect.storage.common.StorageCommonConfig.TOPICS_DIR_DOC;
+import static io.confluent.connect.storage.hive.HiveConfig.HIVE_DATABASE_CONFIG;
+import static io.confluent.connect.storage.hive.HiveConfig.HIVE_INTEGRATION_CONFIG;
 
 public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
 
@@ -738,6 +740,19 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public int getTaskId() {
     return taskId;
+  }
+
+  public boolean hiveIntegrationEnabled() {
+    return getBoolean(HIVE_INTEGRATION_CONFIG);
+  }
+
+  public String hiveDatabase() {
+    return getString(HIVE_DATABASE_CONFIG);
+  }
+
+  @SuppressWarnings("unchecked")
+  public Class<? extends HdfsStorage> storageClass() {
+    return (Class<? extends HdfsStorage>) getClass(StorageCommonConfig.STORAGE_CLASS_CONFIG);
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -514,6 +514,7 @@ public class TopicPartitionWriter {
   }
 
   public void buffer(SinkRecord sinkRecord) {
+    log.trace("Buffering record with offset {}", sinkRecord.kafkaOffset());
     buffer.add(sinkRecord);
   }
 
@@ -609,8 +610,10 @@ public class TopicPartitionWriter {
     if (fileStatusWithMaxOffset != null) {
       long lastCommittedOffsetToHdfs = FileUtils.extractOffset(
           fileStatusWithMaxOffset.getPath().getName());
+      log.trace("Last committed offset based on filenames: {}", lastCommittedOffsetToHdfs);
       // `offset` represents the next offset to read after the most recent commit
       offset = lastCommittedOffsetToHdfs + 1;
+      log.trace("Next offset to read: {}", offset);
     }
   }
 


### PR DESCRIPTION
## Problem
* Constructor in `DataWriter` is hard to read and uses an all-encompassing try block that should be broken up to improve legibility and error handling. 
* `FSWAL` code needs a minor refactor in `apply` to make code more readable and prepare for upcoming changes. 
* `HdfsSinkTask` and `FSWAL` do not adhere to logging standards and could use improved logging.  

## Solution
* Break constructor in `DataWriter` into smaller logical units, and split the try block to improve legibility and error handling. 
* Refactor `FSWAL` and add improved logging. 
* Add improved logging to `HdfsSinkTask` .  

This PR is scoped for review convenience and further refactors may follow. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backporting to `5.5.x` where `CorruptWalFileException` was added.