### PR TITLE
CCMSG-670: Use WAL file as primary for offset recovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>10.0.4</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>10.1.0</kafka.connect.storage.common.version>
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -117,7 +117,8 @@ public class HdfsSinkTask extends SinkTask {
 
     log.info("The connector relies on offsets in HDFS filenames, but does commit these offsets to "
         + "Connect to enable monitoring progress of the HDFS connector. Upon startup, the HDFS "
-        + "Connector restores offsets from filenames in HDFS. In the absence of files in HDFS, "
+        + "Connector restores offsets from the WAL log files, if these are not present it "
+        + "uses the filenames in HDFS. In the absence of files in HDFS, "
         + "the connector will attempt to find offsets for its consumer group in the "
         + "'__consumer_offsets' topic. If offsets are not found, the consumer will "
         + "rely on the reset policy specified in the 'consumer.auto.offset.reset' property to "

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -115,8 +115,9 @@ public class HdfsSinkTask extends SinkTask {
       throw e;
     }
 
-    log.info("The connector relies on offsets in HDFS filenames, but does commit these offsets to "
-        + "Connect to enable monitoring progress of the HDFS connector. Upon startup, the HDFS "
+    log.info("The connector relies on offsets in the WAL files, if these are not present it uses "
+        + "the filenames in HDFS, and in both cases commits these offsets to Connect to "
+        + "enable monitoring progress of the HDFS connector. Upon startup, the HDFS "
         + "Connector restores offsets from the WAL log files, if these are not present it "
         + "uses the filenames in HDFS. In the absence of files in HDFS, "
         + "the connector will attempt to find offsets for its consumer group in the "

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -116,7 +116,7 @@ public class HdfsSinkTask extends SinkTask {
     }
 
     log.info("The connector relies on offsets in the WAL files, if these are not present it uses "
-        + "the filenames in HDFS, and in both cases commits these offsets to Connect to "
+        + "the filenames in HDFS. In both cases the connector commits offsets to Connect to "
         + "enable monitoring progress of the HDFS connector. Upon startup, the HDFS "
         + "Connector restores offsets from the WAL log files, if these are not present it "
         + "uses the filenames in HDFS. In the absence of files in HDFS, "

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -617,7 +617,7 @@ public class TopicPartitionWriter {
 
     // Use the recursive filename scan approach
     log.debug("Could not use WAL approach for recovering offsets, "
-        + "searching for latest offsets on filesystem.");
+        + "searching for latest offsets on HDFS.");
     String path = FileUtils.topicDirectory(url, topicsDir, tp.topic());
     CommittedFileFilter filter = new TopicPartitionCommittedFileFilter(tp);
     FileStatus fileStatusWithMaxOffset = FileUtils.fileStatusWithMaxOffset(

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -811,7 +811,7 @@ public class TopicPartitionWriter {
             connectorConfig,
             new Path(latestOffsetsFile)
         );
-        log.trace("Retrieved schema from file with latest offset {}", latestOffsetsFile);
+        log.debug("Retrieved schema from file with latest offset {}", latestOffsetsFile);
       } else {
         // if WAL restored file is N/A fallback on a recursive scan approach of filenames
         log.debug("Could not find latest offsets file from WAL for schema initialization, "
@@ -829,7 +829,7 @@ public class TopicPartitionWriter {
               connectorConfig,
               fileStatusWithMaxOffset.getPath()
           );
-          log.trace("Retrieved schema from file with latest offset {}", latestOffsetsFile);
+          log.debug("Retrieved schema from file with latest offset {}", fileStatusWithMaxOffset);
         }
       }
     }

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -16,7 +16,7 @@
 package io.confluent.connect.hdfs;
 
 import io.confluent.connect.hdfs.wal.FSWAL;
-import org.apache.commons.lang3.tuple.Pair;
+import io.confluent.connect.storage.wal.FilePathOffset;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
@@ -627,11 +627,11 @@ public class TopicPartitionWriter {
   private boolean readOffsetFromWAL() {
     // MemoryWAL is used for testing
     if (wal instanceof FSWAL) {
-      Pair<Long, String> latestOffsetEntry = ((FSWAL) wal).extractLatestOffsetFromWAL();
+      FilePathOffset latestOffsetEntry = wal.extractLatestOffset();
       if (latestOffsetEntry == null) {
         return false;
       }
-      long lastCommittedOffset = latestOffsetEntry.getKey();
+      long lastCommittedOffset = latestOffsetEntry.getOffset();
       log.trace("Last committed offset based on WAL: {}", lastCommittedOffset);
       offset = lastCommittedOffset + 1;
       log.trace("Next offset to read: {}", offset);

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -855,10 +855,10 @@ public class TopicPartitionWriter {
   }
 
   private void commitFile(String encodedPartition) {
-    log.debug("Committing file for partition {}", encodedPartition);
     if (!startOffsets.containsKey(encodedPartition)) {
       return;
     }
+    log.debug("Committing file for partition {}", encodedPartition);
     long startOffset = startOffsets.get(encodedPartition);
     long endOffset = offsets.get(encodedPartition);
     String tempFile = tempFiles.get(encodedPartition);

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -703,6 +703,8 @@ public class TopicPartitionWriter {
     if (!recovered) {
       if (!readOffsetFromWAL()) {
         // fallback on existing approach
+        log.debug("Could not use WAL approach for recovering offsets, "
+            + "searching for latest offsets on filesystem.");
         readOffsetFromFilenames();
       }
       // Note that we must *always* request that we seek to an offset here. Currently the
@@ -810,6 +812,8 @@ public class TopicPartitionWriter {
         log.trace("Retrieved schema from file with latest offset {}", latestOffsetsFile);
       } else {
         // if WAL restored file is N/A fallback on existing recursive scan approach
+        log.debug("Could not find latest offsets file from WAL for schema initialization, "
+            + "searching for latest offsets file on filesystem.");
         String topicDir = FileUtils.topicDirectory(url, topicsDir, tp.topic());
         CommittedFileFilter filter = new TopicPartitionCommittedFileFilter(tp);
         log.trace("Fetching file with max offset.");

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -702,7 +702,7 @@ public class TopicPartitionWriter {
   private void resetOffsets() throws ConnectException {
     if (!recovered) {
       if (!readOffsetFromWAL()) {
-        // fallback on existing approach
+        // fallback on recursive filename search approach
         log.debug("Could not use WAL approach for recovering offsets, "
             + "searching for latest offsets on filesystem.");
         readOffsetFromFilenames();
@@ -802,7 +802,8 @@ public class TopicPartitionWriter {
 
   private void fetchSchemaFromLatestFile() {
     if (compatibility != StorageSchemaCompatibility.NONE && offset != -1) {
-      log.debug("Current schema is null, getting schema from file with latest offsets.");
+      log.debug("Current schema is not set for partition {}, "
+          + "getting schema from file with latest offsets.", tp);
       // check on WAL restored latest file to avoid recursive search
       if (recovered && latestOffsetsFile != null) {
         currentSchema = schemaFileReader.getSchema(
@@ -811,7 +812,7 @@ public class TopicPartitionWriter {
         );
         log.trace("Retrieved schema from file with latest offset {}", latestOffsetsFile);
       } else {
-        // if WAL restored file is N/A fallback on existing recursive scan approach
+        // if WAL restored file is N/A fallback on a recursive scan approach of filenames
         log.debug("Could not find latest offsets file from WAL for schema initialization, "
             + "searching for latest offsets file on filesystem.");
         String topicDir = FileUtils.topicDirectory(url, topicsDir, tp.topic());

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -15,8 +15,6 @@
 
 package io.confluent.connect.hdfs;
 
-import io.confluent.connect.hdfs.wal.FSWAL;
-import io.confluent.connect.storage.wal.FilePathOffset;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
@@ -60,6 +58,7 @@ import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
 import io.confluent.connect.storage.partitioner.TimestampExtractor;
 import io.confluent.connect.storage.schema.StorageSchemaCompatibility;
 import io.confluent.connect.storage.wal.WAL;
+import io.confluent.connect.storage.wal.FilePathOffset;
 
 public class TopicPartitionWriter {
   private static final Logger log = LoggerFactory.getLogger(TopicPartitionWriter.class);
@@ -625,19 +624,15 @@ public class TopicPartitionWriter {
    * @return whether a valid offset was read
    */
   private boolean readOffsetFromWAL() {
-    // MemoryWAL is used for testing
-    if (wal instanceof FSWAL) {
-      FilePathOffset latestOffsetEntry = wal.extractLatestOffset();
-      if (latestOffsetEntry == null) {
-        return false;
-      }
-      long lastCommittedOffset = latestOffsetEntry.getOffset();
-      log.trace("Last committed offset based on WAL: {}", lastCommittedOffset);
-      offset = lastCommittedOffset + 1;
-      log.trace("Next offset to read: {}", offset);
-      return true;
+    FilePathOffset latestOffsetEntry = wal.extractLatestOffset();
+    if (latestOffsetEntry == null) {
+      return false;
     }
-    return false;
+    long lastCommittedOffset = latestOffsetEntry.getOffset();
+    log.trace("Last committed offset based on WAL: {}", lastCommittedOffset);
+    offset = lastCommittedOffset + 1;
+    log.trace("Next offset to read: {}", offset);
+    return true;
   }
 
   private void pause() {

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -619,8 +619,9 @@ public class TopicPartitionWriter {
       if (latestOffsetEntry == null) {
         return false;
       }
-      log.trace("Last committed offset based on WAL: {}", latestOffsetEntry.getKey());
-      offset = latestOffsetEntry.getKey() + 1;
+      long lastCommittedOffset = latestOffsetEntry.getKey();
+      log.trace("Last committed offset based on WAL: {}", lastCommittedOffset);
+      offset = lastCommittedOffset + 1;
       log.trace("Next offset to read: {}", offset);
       latestOffsetsFile = latestOffsetEntry.getValue();
       log.trace("Set latest offsets file {}", latestOffsetsFile);

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -223,7 +223,7 @@ public class FSWAL implements WAL {
         Reader oldFileReader =
             new WALFile.Reader(conf.getHadoopConfiguration(), Reader.file(new Path(oldWALFile)));
         List<String> committedFileBatch = getLastFilledBlockFromWAL(oldFileReader);
-        latestOffset = getLatestOffsetFromList(committedFileBatch);;
+        latestOffset = getLatestOffsetFromList(committedFileBatch);
         oldFileReader.close();
       }
       return latestOffset;
@@ -302,7 +302,7 @@ public class FSWAL implements WAL {
         return FileUtils.extractOffset(latestFileName);
       }
     } catch (IllegalArgumentException e) {
-      log.warn("Could not extract offsets from file path: {}", fullPath);
+      log.warn("Could not extract offsets from file path {}: {}", fullPath, e.getMessage());
     }
     return -1;
   }

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -220,11 +220,12 @@ public class FSWAL implements WAL {
       // attempt to use old log file if recent WAL is empty or non-existent
       if (latestOffset == null && storage.exists(oldWALFile)) {
         log.trace("Could not find offset in log file {}. Using {} instead", logFile, oldWALFile);
-        Reader oldFileReader =
-            new WALFile.Reader(conf.getHadoopConfiguration(), Reader.file(new Path(oldWALFile)));
-        List<String> committedFileBatch = getLastFilledBlockFromWAL(oldFileReader);
-        latestOffset = getLatestOffsetFromList(committedFileBatch);
-        oldFileReader.close();
+        try (Reader oldFileReader =
+            new WALFile.Reader(conf.getHadoopConfiguration(), Reader.file(new Path(oldWALFile)))
+        ) {
+          List<String> committedFileBatch = getLastFilledBlockFromWAL(oldFileReader);
+          latestOffset = getLatestOffsetFromList(committedFileBatch);
+        }
       }
       return latestOffset;
     } catch (IOException e) {

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -271,7 +271,8 @@ public class FSWAL implements WAL {
       } else if (keyName.equals(endMarker)) {
         if (entryBlockStarted && !tempFilenames.isEmpty()) {
           // only save non-empty blocks
-          committedFilenames = new ArrayList<>(tempFilenames);
+          committedFilenames.clear();
+          committedFilenames.addAll(tempFilenames);
         }
         tempFilenames.clear();
         entryBlockStarted = false;

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -190,11 +190,11 @@ public class FSWAL implements WAL {
 
   /**
    * Extract the latest offset and file path from the WAL file.
-   * Attempt with the most recent WAL file, and fall back to the old file if it's not applicable.
+   * Attempt with the most recent WAL file and fall back to the old file if it's not applicable.
    *
    * <p> The old WAL is used when the most recent WAL file has already been truncated
-   * and is not existent, which may happen when the connector has flushed all records,
-   * and is restarted. </p>
+   * and does not exist, which may happen when the connector is restarted after having flushed
+   * all the records. </p>
    *
    * @return the latest offset and filepath from the WAL file or null
    */

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -15,11 +15,11 @@
 
 package io.confluent.connect.hdfs.wal;
 
+import io.confluent.connect.storage.wal.FilePathOffset;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 
 import java.util.List;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.kafka.common.TopicPartition;
@@ -199,10 +199,11 @@ public class FSWAL implements WAL {
    *
    * @return the latest offset and filepath from the WAL file or null
    */
-  public Pair<Long, String> extractLatestOffsetFromWAL() {
+  @Override
+  public FilePathOffset extractLatestOffset() {
     String oldWALFile = logFile + TRUNCATED_LOG_EXTENSION;
     try {
-      Pair<Long, String> latestOffset = null;
+      FilePathOffset latestOffset = null;
       if (storage.exists(logFile)) {
         log.trace("Restoring offset from WAL file: {}", logFile);
         if (reader == null) {
@@ -299,15 +300,15 @@ public class FSWAL implements WAL {
    * @param committedFileNames a list of committed filenames
    * @return the latest offset committed along with the filepath
    */
-  private Pair<Long, String> getLatestOffsetFromList(List<String> committedFileNames) {
-    Pair<Long, String> latestOffsetEntry = null;
+  private FilePathOffset getLatestOffsetFromList(List<String> committedFileNames) {
+    FilePathOffset latestOffsetEntry = null;
     long latestOffset = -1;
     // Entries in the BEGIN-END block are currently not guaranteed any ordering.
     for (String fileName : committedFileNames) {
       long currentOffset = extractOffsetsFromFilePath(fileName);
       if (currentOffset > latestOffset) {
         latestOffset = currentOffset;
-        latestOffsetEntry = Pair.of(latestOffset, fileName);
+        latestOffsetEntry = new FilePathOffset(latestOffset, fileName);
       }
     }
     return latestOffsetEntry;

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -15,11 +15,6 @@
 
 package io.confluent.connect.hdfs.wal;
 
-import io.confluent.connect.storage.wal.FilePathOffset;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-
-import java.util.List;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.kafka.common.TopicPartition;
@@ -29,14 +24,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.nio.file.Paths;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
 
 import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.hdfs.wal.WALFile.Reader;
 import io.confluent.connect.hdfs.wal.WALFile.Writer;
+import io.confluent.connect.storage.wal.FilePathOffset;
 
 public class FSWAL implements WAL {
 

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -338,10 +338,10 @@ public class FSWAL implements WAL {
 
   @Override
   public void truncate() throws ConnectException {
-    log.debug("Truncating WAL file: {}", logFile);
     try {
       String oldLogFile = logFile + TRUNCATED_LOG_EXTENSION;
       if (storage.exists(logFile)) {
+        log.debug("Truncating WAL file: {}", logFile);
         // The old WAL file should only be deleted if there is a new one to replace it.
         // Otherwise the old log file will be lost on 2+ restarts with an empty buffer.
         storage.delete(oldLogFile);

--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -928,6 +928,15 @@ public class WALFile {
     }
 
     /**
+     * Seek to the start of the file after the header.
+     *
+     * @throws IOException if unable to seek to the end of the header
+     */
+    public void seekToFirstRecord() throws IOException {
+      in.seek(headerEnd);
+    }
+
+    /**
      * Seek to the next sync mark past a given position.
      *
      * @param position sync mark will be found past the given position.

--- a/src/test/java/io/confluent/connect/hdfs/utils/MemoryWAL.java
+++ b/src/test/java/io/confluent/connect/hdfs/utils/MemoryWAL.java
@@ -15,7 +15,6 @@
 
 package io.confluent.connect.hdfs.utils;
 
-import io.confluent.connect.storage.wal.FilePathOffset;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 
@@ -24,6 +23,7 @@ import java.util.Map;
 
 import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.wal.WAL;
+import io.confluent.connect.storage.wal.FilePathOffset;
 
 public class MemoryWAL implements WAL {
 

--- a/src/test/java/io/confluent/connect/hdfs/utils/MemoryWAL.java
+++ b/src/test/java/io/confluent/connect/hdfs/utils/MemoryWAL.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.hdfs.utils;
 
+import io.confluent.connect.storage.wal.FilePathOffset;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 
@@ -22,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import io.confluent.connect.hdfs.FileUtils;
-import io.confluent.connect.hdfs.storage.Storage;
 import io.confluent.connect.hdfs.wal.WAL;
 
 public class MemoryWAL implements WAL {
@@ -75,6 +75,11 @@ public class MemoryWAL implements WAL {
   @Override
   public String getLogFile() {
     return logFile;
+  }
+
+  @Override
+  public FilePathOffset extractLatestOffset() {
+    return null;
   }
 
   private static class LogEntry {

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -15,19 +15,19 @@
 
 package io.confluent.connect.hdfs.wal;
 
-import io.confluent.connect.hdfs.DataWriter;
-import io.confluent.connect.hdfs.FileUtils;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+import java.io.OutputStream;
+import java.io.IOException;
+
+import io.confluent.connect.hdfs.DataWriter;
+import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
-
-import java.io.OutputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -112,7 +112,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
 
     assertNull(wal.extractLatestOffset());
 
-    addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal);
+    addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
     wal.append(WAL.beginMarker, "");
@@ -130,7 +130,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
 
     wal.append(WAL.beginMarker, "");
-    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
+    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     // missing end marker here
 
     wal.append(WAL.beginMarker, "");
@@ -154,7 +154,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.endMarker, "");
 
     wal.append(WAL.beginMarker, "");
-    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
+    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     // missing end marker here
 
     wal.append(WAL.beginMarker, "");
@@ -186,7 +186,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
     wal.append(WAL.beginMarker, "");
-    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
+    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     wal.close();
     //missing end marker here
     assertEquals(expectedOffset, wal.extractLatestOffset().getOffset());
@@ -201,8 +201,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
     wal.append(WAL.beginMarker, "");
-    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
-    wal.close();
+    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     //missing end marker here
     assertNull(wal.extractLatestOffset());
   }
@@ -214,7 +213,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
 
     //test missing begin marker
-    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
+    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     wal.append(WAL.endMarker, "");
     wal.close();
     assertNull(wal.extractLatestOffset());
@@ -231,7 +230,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
     //test missing begin marker
-    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
+    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     wal.append(WAL.endMarker, "");
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
@@ -252,7 +251,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
     //test missing begin marker
-    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
+    addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     wal.append(WAL.endMarker, "");
     wal.close();
     assertNull(wal.extractLatestOffset());
@@ -263,7 +262,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
     FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
-    addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal);
+    addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
 
     long latestOffset = wal.extractLatestOffset().getOffset();
     assertEquals(49, latestOffset);
@@ -274,7 +273,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
     FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
-    addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal);
+    addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     //creates old WAL and empties new one
     wal.truncate();
 
@@ -290,15 +289,15 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     partitioner = hdfsWriter.getPartitioner();
   }
 
-  private void addSampleEntriesToWAL(String topicsDir, WAL wal) throws IOException {
+  private void addSampleEntriesToWAL(String topicsDir, WAL wal, int numEntries) throws IOException {
     wal.append(WAL.beginMarker, "");
-    addSampleEntriesToWALNoMarkers(topicsDir, wal);
+    addSampleEntriesToWALNoMarkers(topicsDir, wal, numEntries);
     wal.append(WAL.endMarker, "");
     wal.close();
   }
 
-  private void addSampleEntriesToWALNoMarkers(String topicsDir, WAL wal) throws IOException {
-    for (int i = 0; i < 5; ++i) {
+  private void addSampleEntriesToWALNoMarkers(String topicsDir, WAL wal, int numEntries) throws IOException {
+    for (int i = 0; i < numEntries; ++i) {
       long startOffset = i * 10;
       long endOffset = (i + 1) * 10 - 1;
       String tempfile = FileUtils.tempFileName(url, topicsDir, getDirectory(), extension);

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -100,12 +100,8 @@ public class FSWALTest extends TestWithMiniDFSCluster {
 
   @Test
   public void testOffsetsExtractedFromWALWithEmptyBlocks() throws Exception {
-    setUp();
-    String topicsDir = this.topicsDir.get(TOPIC_PARTITION.topic());
-    fs.delete(new Path(FileUtils.directoryName(url, topicsDir, TOPIC_PARTITION)), true);
+    setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
-    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    partitioner = hdfsWriter.getPartitioner();
 
     FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
     //create a few empty blocks
@@ -116,7 +112,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
 
     assertNull(wal.extractLatestOffset());
 
-    addSampleEntriesToWAL(topicsDir, wal);
+    addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal);
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
     wal.append(WAL.beginMarker, "");

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class FSWALTest extends TestWithMiniDFSCluster {
@@ -113,8 +114,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
 
-    long latestOffset = wal.extractLatestOffsetFromWAL();
-    assertEquals(-1, latestOffset);
+    assertNull(wal.extractLatestOffsetFromWAL());
 
     addSampleEntriesToWAL(topicsDir, wal);
     wal.append(WAL.beginMarker, "");
@@ -122,7 +122,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
 
-    latestOffset = wal.extractLatestOffsetFromWAL();
+    long latestOffset = wal.extractLatestOffsetFromWAL().getKey();
     assertEquals(49, latestOffset);
   }
 
@@ -138,7 +138,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
     addSampleEntriesToWAL(topicsDir, wal);
 
-    long latestOffset = wal.extractLatestOffsetFromWAL();
+    long latestOffset = wal.extractLatestOffsetFromWAL().getKey();
     assertEquals(49, latestOffset);
   }
 
@@ -156,7 +156,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     //creates old WAL and empties new one
     wal.truncate();
 
-    long latestOffset = wal.extractLatestOffsetFromWAL();
+    long latestOffset = wal.extractLatestOffsetFromWAL().getKey();
     assertEquals(49, latestOffset);
   }
 

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -114,7 +114,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
 
-    assertNull(wal.extractLatestOffsetFromWAL());
+    assertNull(wal.extractLatestOffset());
 
     addSampleEntriesToWAL(topicsDir, wal);
     wal.append(WAL.beginMarker, "");
@@ -122,7 +122,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
 
-    long latestOffset = wal.extractLatestOffsetFromWAL().getKey();
+    long latestOffset = wal.extractLatestOffset().getOffset();
     assertEquals(49, latestOffset);
   }
 
@@ -142,7 +142,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.endMarker, "");
     wal.close();
 
-    assertNull(wal.extractLatestOffsetFromWAL());
+    assertNull(wal.extractLatestOffset());
   }
 
   @Test
@@ -166,7 +166,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.endMarker, "");
     wal.close();
 
-    assertNull(wal.extractLatestOffsetFromWAL());
+    assertNull(wal.extractLatestOffset());
   }
 
   @Test
@@ -193,7 +193,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
     wal.close();
     //missing end marker here
-    assertEquals(new Long(expectedOffset), wal.extractLatestOffsetFromWAL().getKey());
+    assertEquals(expectedOffset, wal.extractLatestOffset().getOffset());
   }
 
   @Test
@@ -208,7 +208,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
     wal.close();
     //missing end marker here
-    assertNull(wal.extractLatestOffsetFromWAL());
+    assertNull(wal.extractLatestOffset());
   }
 
   @Test
@@ -221,7 +221,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
     wal.append(WAL.endMarker, "");
     wal.close();
-    assertNull(wal.extractLatestOffsetFromWAL());
+    assertNull(wal.extractLatestOffset());
   }
 
   @Test
@@ -242,7 +242,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
     wal.close();
-    assertNull(wal.extractLatestOffsetFromWAL());
+    assertNull(wal.extractLatestOffset());
   }
 
   @Test
@@ -259,7 +259,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal);
     wal.append(WAL.endMarker, "");
     wal.close();
-    assertNull(wal.extractLatestOffsetFromWAL());
+    assertNull(wal.extractLatestOffset());
   }
 
   @Test
@@ -269,7 +269,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
     addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal);
 
-    long latestOffset = wal.extractLatestOffsetFromWAL().getKey();
+    long latestOffset = wal.extractLatestOffset().getOffset();
     assertEquals(49, latestOffset);
   }
 
@@ -282,7 +282,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     //creates old WAL and empties new one
     wal.truncate();
 
-    long latestOffset = wal.extractLatestOffsetFromWAL().getKey();
+    long latestOffset = wal.extractLatestOffset().getOffset();
     assertEquals(49, latestOffset);
   }
 


### PR DESCRIPTION
## Problem
The HDFS connector tracks Kafka offsets through the names of the files written to HDFS. 
1. On startup, the connector attempts to recover the most recently committed offsets by recursively scanning the `topics.dir` for each topic partition it has been assigned, and then resumes consuming from those offsets. 

2. On write, when the schema is initialized the connector performs the same recursive search. 

The recursive file listing operation becomes expensive when there are thousands or millions of files and the connector takes a long time to start. 

## Solution

Use the stored offsets from the `WAL` file as a primary method for recovery. Fall-back on the current approach as a backup and for backwards compatibility when the `WAL` is not readable or non-existent. 

**Summary of functional changes**

`TopicPartitionWriter.java`
* The offsets are now attempted to be reset before truncating the existing `WAL`. Currently, truncating before resetting would cause the old `WAL` to be deleted before extracting the offset information. 
* Reset the offsets based on the `WAL` and if not applicable use the current method as fallback. 
* Use the file path of the latest offsets file that was extracted from the `WAL` for the schema initialization as well to avoid the recursive search. Fallback on recursive. 

`FSWAL.java`
* Added offset extraction logic for both recent and truncated (old) `WAL`. 

`WALFile.java`
* Added method to seek to the beginning of the first record for a file `Reader`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
`10.0.x` for major change.   