### PR TITLE
CCMSG-953: work around wal CannotObtainBlockLengthException

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.hadoop.hdfs.CannotObtainBlockLengthException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,6 +142,10 @@ public class FSWAL implements WAL {
     } catch (CorruptWalFileException e) {
       log.error("Error applying WAL file '{}' because it is corrupted: {}", logFile, e);
       log.warn("Truncating and skipping corrupt WAL file '{}'.", logFile);
+      close();
+    } catch (CannotObtainBlockLengthException e) {
+      log.error("Error applying WAL file '{}'as not able to obtain block length: {}", logFile, e);
+      log.warn("Truncating and skipping the WAL file '{}'.", logFile);
       close();
     } catch (IOException e) {
       log.error("Error applying WAL file: {}, {}", logFile, e);

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -144,8 +144,8 @@ public class FSWAL implements WAL {
       log.warn("Truncating and skipping corrupt WAL file '{}'.", logFile);
       close();
     } catch (CannotObtainBlockLengthException e) {
-      log.error("Error applying WAL file '{}' because the task cannot obtain block length: {}",
-          logFile, e);
+      log.error("Error applying WAL file '{}' because the task cannot obtain "
+          + "the block length from HDFS: {}", logFile, e);
       log.warn("Truncating and skipping the WAL file '{}'.", logFile);
       close();
     } catch (IOException e) {

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -144,7 +144,8 @@ public class FSWAL implements WAL {
       log.warn("Truncating and skipping corrupt WAL file '{}'.", logFile);
       close();
     } catch (CannotObtainBlockLengthException e) {
-      log.error("Error applying WAL file '{}'as not able to obtain block length: {}", logFile, e);
+      log.error("Error applying WAL file '{}' because the task cannot obtain block length: {}",
+          logFile, e);
       log.warn("Truncating and skipping the WAL file '{}'.", logFile);
       close();
     } catch (IOException e) {

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -308,4 +308,19 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     }
   }
 
+  @Test
+  public void testApply() throws Exception {
+    setUp();
+    System.out.println("Testing testApply...");
+    HdfsStorage storage = new HdfsStorage(connectorConfig, url);
+    TopicPartition tp = new TopicPartition("mytopic", 123);
+    FSWAL wal = new FSWAL("/logs", tp, storage);
+    wal.append("a", "b");
+    assertTrue("WAL file should exist after append",
+            storage.exists("/logs/mytopic/123/log"));
+    wal.apply();
+    wal.append("x", "y");
+    wal.apply();
+  }
+
 }


### PR DESCRIPTION
## Problem

During task restart or connector configuration change, CannotObtainBlockLengthException can happen during WAL file apply. 

```
ERROR [90455_DMZ_fedd_hdfs_sink_testing_04_23_2021|task-0] Error applying WAL file: hdfs://SFP-UAT/tenants/90455/shared/gti_dbus_dmz/logs/topic-rl-100031-89345/7/log, {} (io.confluent.connect.hdfs.wal.FSWAL:156)
org.apache.hadoop.hdfs.CannotObtainBlockLengthException: Cannot obtain block length for LocatedBlock{BP-679409434-169.84.229.54-1449158097549:blk_2272402293_1199287568; getBlockSize()=6407; corrupt=false; offset=0; locs=[DatanodeInfoWithStorage[169.127.76.17:50010,DS-bc4eba2c-a5e0-46da-824d-3bd9c3c0da2e,DISK], DatanodeInfoWithStorage[169.84.230.15:50010,DS-bf60049b-1981-490a-9b16-04f8d563bf63,DISK], DatanodeInfoWithStorage[169.125.212.143:50010,DS-103ee265-f2c5-4b0f-b536-3d75b887a5dc,DISK]]} of /tenants/90455/shared/gti_dbus_dmz/logs/topic-rl-100031-89345/7/log
at org.apache.hadoop.hdfs.DFSInputStream.readBlockLength(DFSInputStream.java:470)
at org.apache.hadoop.hdfs.DFSInputStream.fetchLocatedBlocksAndGetLastBlockLength(DFSInputStream.java:377)
at org.apache.hadoop.hdfs.DFSInputStream.openInfo(DFSInputStream.java:307)
at org.apache.hadoop.hdfs.DFSInputStream.<init>(DFSInputStream.java:292)
at org.apache.hadoop.hdfs.DFSClient.open(DFSClient.java:1087)
at org.apache.hadoop.hdfs.DistributedFileSystem$4.doCall(DistributedFileSystem.java:327)
at org.apache.hadoop.hdfs.DistributedFileSystem$4.doCall(DistributedFileSystem.java:324)
at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
at org.apache.hadoop.hdfs.DistributedFileSystem.open(DistributedFileSystem.java:324)
at io.confluent.connect.hdfs.wal.WALFile$Reader.openFile(WALFile.java:589)
at io.confluent.connect.hdfs.wal.WALFile$Reader.<init>(WALFile.java:470)
at io.confluent.connect.hdfs.wal.FSWAL.apply(FSWAL.java:128)
at io.confluent.connect.hdfs.TopicPartitionWriter.applyWAL(TopicPartitionWriter.java:679)
at io.confluent.connect.hdfs.TopicPartitionWriter.recover(TopicPartitionWriter.java:258)
at io.confluent.connect.hdfs.DataWriter.recover(DataWriter.java:374)
at io.confluent.connect.hdfs.DataWriter.open(DataWriter.java:437)
at io.confluent.connect.hdfs.HdfsSinkTask.open(HdfsSinkTask.java:163)
at org.apache.kafka.connect.runtime.WorkerSinkTask.openPartitions(WorkerSinkTask.java:617)
at org.apache.kafka.connect.runtime.WorkerSinkTask.access$1100(WorkerSinkTask.java:71)
at org.apache.kafka.connect.runtime.WorkerSinkTask$HandleRebalance.onPartitionsAssigned(WorkerSinkTask.java:682)
at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.invokePartitionsAssigned(ConsumerCoordinator.java:293)
at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.onJoinComplete(ConsumerCoordinator.java:430)
at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.joinGroupIfNeeded(AbstractCoordinator.java:451)
at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.ensureActiveGroup(AbstractCoordinator.java:367)
at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.poll(ConsumerCoordinator.java:508)
at org.apache.kafka.clients.consumer.KafkaConsumer.updateAssignmentMetadataIfNeeded(KafkaConsumer.java:1261)
at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1230)
at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1210)
at org.apache.kafka.connect.runtime.WorkerSinkTask.pollConsumer(WorkerSinkTask.java:454)
at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:321)
at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:229)
at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:201)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:185)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:235)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
```
## Solution

Allow connector process continue by log the error.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ *] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ *] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
