### PR TITLE
MINOR: adopt java8 features and cleanup

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -39,7 +39,7 @@
 
     <suppress
             checks="NPathComplexity"
-            files="(TopicPartitionWriter|WALFile).java"
+            files="(TopicPartitionWriter|WALFile|DataWriter).java"
     />
 
     <suppress

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -156,29 +156,7 @@ public class DataWriter {
         log.info("Login as: " + ugi.getUserName());
 
         isRunning = true;
-        ticketRenewThread = new Thread(new Runnable() {
-          @Override
-          public void run() {
-            synchronized (DataWriter.this) {
-              while (isRunning) {
-                try {
-                  DataWriter.this.wait(config.kerberosTicketRenewPeriodMs());
-                  if (isRunning) {
-                    ugi.reloginFromKeytab();
-                  }
-                } catch (IOException e) {
-                  // We ignore this exception during relogin as each successful relogin gives
-                  // additional 24 hours of authentication in the default config. In normal
-                  // situations, the probability of failing relogin 24 times is low and if
-                  // that happens, the task will fail eventually.
-                  log.error("Error renewing the ticket", e);
-                } catch (InterruptedException e) {
-                  // ignored
-                }
-              }
-            }
-          }
-        });
+        ticketRenewThread = new Thread(() -> renewKerberosTicket(ugi));
         log.info(
             "Starting the Kerberos ticket renew thread with period {} ms.",
             config.kerberosTicketRenewPeriodMs()
@@ -620,5 +598,26 @@ public class DataWriter {
     map.put(PartitionerConfig.LOCALE_CONFIG, config.getString(PartitionerConfig.LOCALE_CONFIG));
     map.put(PartitionerConfig.TIMEZONE_CONFIG, config.getString(PartitionerConfig.TIMEZONE_CONFIG));
     return map;
+  }
+
+  private void renewKerberosTicket(UserGroupInformation ugi) {
+    synchronized (DataWriter.this) {
+      while (isRunning) {
+        try {
+          DataWriter.this.wait(connectorConfig.kerberosTicketRenewPeriodMs());
+          if (isRunning) {
+            ugi.reloginFromKeytab();
+          }
+        } catch (IOException e) {
+          // We ignore this exception during relogin as each successful relogin gives
+          // additional 24 hours of authentication in the default config. In normal
+          // situations, the probability of failing relogin 24 times is low and if
+          // that happens, the task will fail eventually.
+          log.error("Error renewing the ticket", e);
+        } catch (InterruptedException e) {
+          // ignored
+        }
+      }
+    }
   }
 }

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -129,11 +129,11 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
 
   static {
     STORAGE_CLASS_RECOMMENDER.addValidValues(
-        Arrays.<Object>asList(HdfsStorage.class)
+        Arrays.asList(HdfsStorage.class)
     );
 
     FORMAT_CLASS_RECOMMENDER.addValidValues(
-        Arrays.<Object>asList(
+        Arrays.asList(
             AvroFormat.class,
             JsonFormat.class,
             ParquetFormat.class,
@@ -142,7 +142,7 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     );
 
     PARTITIONER_CLASS_RECOMMENDER.addValidValues(
-        Arrays.<Object>asList(
+        Arrays.asList(
             DefaultPartitioner.class,
             HourlyPartitioner.class,
             DailyPartitioner.class,

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -874,46 +873,37 @@ public class TopicPartitionWriter {
   }
 
   private void createHiveTable() {
-    Future<Void> future = executorService.submit(new Callable<Void>() {
-      @Override
-      public Void call() throws HiveMetaStoreException {
-        try {
-          hive.createTable(hiveDatabase, tp.topic(), currentSchema, partitioner);
-        } catch (Throwable e) {
-          log.error("Creating Hive table threw unexpected error", e);
-        }
-        return null;
+    Future<Void> future = executorService.submit(() -> {
+      try {
+        hive.createTable(hiveDatabase, tp.topic(), currentSchema, partitioner);
+      } catch (Throwable e) {
+        log.error("Creating Hive table threw unexpected error", e);
       }
+      return null;
     });
     hiveUpdateFutures.add(future);
   }
 
   private void alterHiveSchema() {
-    Future<Void> future = executorService.submit(new Callable<Void>() {
-      @Override
-      public Void call() throws HiveMetaStoreException {
-        try {
-          hive.alterSchema(hiveDatabase, tp.topic(), currentSchema);
-        } catch (Throwable e) {
-          log.error("Altering Hive schema threw unexpected error", e);
-        }
-        return null;
+    Future<Void> future = executorService.submit(() -> {
+      try {
+        hive.alterSchema(hiveDatabase, tp.topic(), currentSchema);
+      } catch (Throwable e) {
+        log.error("Altering Hive schema threw unexpected error", e);
       }
+      return null;
     });
     hiveUpdateFutures.add(future);
   }
 
   private void addHivePartition(final String location) {
-    Future<Void> future = executorService.submit(new Callable<Void>() {
-      @Override
-      public Void call() throws Exception {
-        try {
-          hiveMetaStore.addPartition(hiveDatabase, tp.topic(), location);
-        } catch (Throwable e) {
-          log.error("Adding Hive partition threw unexpected error", e);
-        }
-        return null;
+    Future<Void> future = executorService.submit(() -> {
+      try {
+        hiveMetaStore.addPartition(hiveDatabase, tp.topic(), location);
+      } catch (Throwable e) {
+        log.error("Adding Hive partition threw unexpected error", e);
       }
+      return null;
     });
     hiveUpdateFutures.add(future);
   }

--- a/src/main/java/io/confluent/connect/hdfs/tools/SchemaSourceTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/tools/SchemaSourceTask.java
@@ -89,9 +89,7 @@ public class SchemaSourceTask extends SourceTask {
       topic = props.get(TOPIC_CONFIG);
       maxNumMsgs = Long.parseLong(props.get(NUM_MSGS_CONFIG));
       multipleSchema = Boolean.parseBoolean(props.get(MULTIPLE_SCHEMA_CONFIG));
-      partitionCount = Integer.parseInt(
-          props.containsKey(PARTITION_COUNT_CONFIG) ? props.get(PARTITION_COUNT_CONFIG) : "1"
-      );
+      partitionCount = Integer.parseInt(props.getOrDefault(PARTITION_COUNT_CONFIG, "1"));
       String throughputStr = props.get(THROUGHPUT_CONFIG);
       if (throughputStr != null) {
         long throughput = Long.parseLong(throughputStr);

--- a/src/test/java/io/confluent/connect/hdfs/TopicPartitionWriterTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/TopicPartitionWriterTest.java
@@ -12,8 +12,9 @@
  * the License.
  **/
 
-package io.confluent.connect.hdfs.avro;
+package io.confluent.connect.hdfs;
 
+import io.confluent.connect.hdfs.avro.AvroDataFileReader;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -38,12 +39,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import io.confluent.common.utils.MockTime;
-import io.confluent.connect.hdfs.DataWriter;
-import io.confluent.connect.hdfs.FileUtils;
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
-import io.confluent.connect.hdfs.RecordWriterProvider;
-import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
-import io.confluent.connect.hdfs.TopicPartitionWriter;
 import io.confluent.connect.hdfs.filter.CommittedFileFilter;
 import io.confluent.connect.hdfs.partitioner.DefaultPartitioner;
 import io.confluent.connect.hdfs.partitioner.FieldPartitioner;
@@ -60,7 +55,6 @@ import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
 import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -37,6 +37,7 @@ import io.confluent.connect.hdfs.DataWriter;
 import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
+import io.confluent.connect.hdfs.TopicPartitionWriterTest;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.hdfs.wal.WAL;
 import io.confluent.connect.storage.hive.HiveConfig;


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
the connector still uses java7 style when it can be updated to rely on java8 features
TPWTest was in the wrong package

## Solution
move TPWTest to the root package and and replace java7 language features with java8

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
run existing tests

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
