### PR TITLE
CCMSG-1004: fix incorrect TopicPartitionWriter internal offset tracking

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -828,7 +828,6 @@ public class TopicPartitionWriter {
     log.debug("Committing files");
     appended.clear();
 
-
     // commit all files and get the latest committed offset
     long latestCommitted = tempFiles.keySet().stream()
         .mapToLong(this::commitFile)

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -97,7 +97,7 @@ public class TopicPartitionWriter {
   private final Set<String> appended;
   private long offset;
   private final Map<String, Long> startOffsets;
-  private final Map<String, Long> offsets;
+  private final Map<String, Long> endOffsets;
   private final long timeoutMs;
   private long failureTime;
   private final StorageSchemaCompatibility compatibility;
@@ -201,7 +201,7 @@ public class TopicPartitionWriter {
     tempFiles = new HashMap<>();
     appended = new HashSet<>();
     startOffsets = new HashMap<>();
-    offsets = new HashMap<>();
+    endOffsets = new HashMap<>();
     state = State.RECOVERY_STARTED;
     failureTime = -1L;
     // The next offset to consume after the last commit (one more than last offset written to HDFS)
@@ -372,7 +372,7 @@ public class TopicPartitionWriter {
                         + "and end offsets {}",
                     tp,
                     startOffsets,
-                    offsets
+                    endOffsets
                 );
                 nextState();
                 // Fall through and try to rotate immediately
@@ -498,7 +498,7 @@ public class TopicPartitionWriter {
       exceptions.add(e);
     }
     startOffsets.clear();
-    offsets.clear();
+    endOffsets.clear();
 
     if (exceptions.size() != 0) {
       StringBuilder sb = new StringBuilder();
@@ -720,7 +720,7 @@ public class TopicPartitionWriter {
     if (!startOffsets.containsKey(encodedPartition)) {
       startOffsets.put(encodedPartition, record.kafkaOffset());
     }
-    offsets.put(encodedPartition, record.kafkaOffset());
+    endOffsets.put(encodedPartition, record.kafkaOffset());
     recordCounter++;
   }
 
@@ -767,7 +767,7 @@ public class TopicPartitionWriter {
           log.error("Failed to delete tmp file {}", tempFiles.get(encodedPartition), e);
         }
         startOffsets.remove(encodedPartition);
-        offsets.remove(encodedPartition);
+        endOffsets.remove(encodedPartition);
         buffer.clear();
       }
 
@@ -788,7 +788,7 @@ public class TopicPartitionWriter {
       return;
     }
     long startOffset = startOffsets.get(encodedPartition);
-    long endOffset = offsets.get(encodedPartition);
+    long endOffset = endOffsets.get(encodedPartition);
     String directory = getDirectory(encodedPartition);
     String committedFile = FileUtils.committedFileName(
         url,
@@ -827,18 +827,25 @@ public class TopicPartitionWriter {
   private void commitFile() {
     log.debug("Committing files");
     appended.clear();
+
+    long latestCommitted = -1;
     for (String encodedPartition : tempFiles.keySet()) {
-      commitFile(encodedPartition);
+      long endOffset = commitFile(encodedPartition);
+      latestCommitted = Math.max(latestCommitted, endOffset);
+    }
+
+    if (latestCommitted != -1) {
+      offset = latestCommitted + 1;
     }
   }
 
-  private void commitFile(String encodedPartition) {
+  private long commitFile(String encodedPartition) {
     log.debug("Committing file for partition {}", encodedPartition);
     if (!startOffsets.containsKey(encodedPartition)) {
-      return;
+      return -1;
     }
     long startOffset = startOffsets.get(encodedPartition);
-    long endOffset = offsets.get(encodedPartition);
+    long endOffset = endOffsets.get(encodedPartition);
     String tempFile = tempFiles.get(encodedPartition);
     String directory = getDirectory(encodedPartition);
     String committedFile = FileUtils.committedFileName(
@@ -858,10 +865,11 @@ public class TopicPartitionWriter {
     }
     storage.commit(tempFile, committedFile);
     startOffsets.remove(encodedPartition);
-    offsets.remove(encodedPartition);
-    offset = offset + recordCounter; // offset of next record to be reading
+    endOffsets.remove(encodedPartition);
     recordCounter = 0;
     log.info("Committed {} for {}", committedFile, tp);
+
+    return endOffset;
   }
 
   private void deleteTempFile(String encodedPartition) {

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -828,13 +828,13 @@ public class TopicPartitionWriter {
     log.debug("Committing files");
     appended.clear();
 
-    long latestCommitted = -1;
-    for (String encodedPartition : tempFiles.keySet()) {
-      long endOffset = commitFile(encodedPartition);
-      latestCommitted = Math.max(latestCommitted, endOffset);
-    }
 
-    if (latestCommitted != -1) {
+    // commit all files and get the latest committed offset
+    long latestCommitted = tempFiles.keySet().stream()
+        .mapToLong(this::commitFile)
+        .max()
+        .orElse(-1);
+    if (latestCommitted > -1) {
       offset = latestCommitted + 1;
     }
   }


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
the connector [keeps track of offsets incorrectly](https://github.com/confluentinc/kafka-connect-hdfs/blob/master/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java#L883) by doing `offset = offset + recordCounter`

this makes the assumption that record offsets increment by 1 which is wrong
because offsets can increase by more than 1. imagine the scenario of a compacted topic which goes from 1 2 3 4 5 6 7 8 9 10 to 2 4 8 10, 10 records to 4, the starting offset is 1 + 10 = 11 is next offset which is correct but after compaction its 1 + 4 = 5, which is wrong. We would be repeating two extra records (8, 10).

## Solution
keep track of the latest offset by getting the largest end offset committed in the group of files committed

caveats: 
solution doesnt address if one file in a batch of commits fails which is relatively rare and only happens with a select few partitioners. 

lets say we use a partitioner that partitions 8 records into two different partitions (and by extension 2 different files) where records 3-6 go to file 1 and records 1-2,7-8 go to file 2. this can happen with a `FieldPartitioner` or the `TimeBasedPartitioner` when using the `RecordFieldTimestampExtractor` if the timestamps are out of order
from an EOS perspective, this group of files needs to be committed together as a transaction so that the next offset to commit will become 9. However they are not atomic transactions. file 1 can succeed to commit, but file 2 can fail to commit. rolling back is impossible because going back to offset 1 we will have duplicate records for 3-6, if we go to offset 7, we will be missing records 1-2.

 in the case if a file fails, we will just conservatively use the old solution of `offset = offset + recordCounter` since this cases also affects the current implementation which means the the risk is actually extremely low and on top of that the connector retries file commits infinitely so the correct offset will be written eventually

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
potentially other sink storage connector i.e S3

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.0.x` because bug