### PR TITLE
CC-14408: Fix empty context assignment in start()

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.hdfs;
 
+import io.confluent.connect.storage.errors.HiveMetaStoreException;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -36,7 +38,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -52,8 +53,6 @@ import java.util.concurrent.TimeUnit;
 import io.confluent.common.utils.SystemTime;
 import io.confluent.common.utils.Time;
 import io.confluent.connect.avro.AvroData;
-import io.confluent.connect.hdfs.filter.CommittedFileFilter;
-import io.confluent.connect.hdfs.filter.TopicCommittedFileFilter;
 import io.confluent.connect.hdfs.hive.HiveMetaStore;
 import io.confluent.connect.hdfs.hive.HiveUtil;
 import io.confluent.connect.hdfs.partitioner.Partitioner;
@@ -70,8 +69,6 @@ public class DataWriter {
 
   private final Map<TopicPartition, TopicPartitionWriter> topicPartitionWriters;
   private HdfsStorage storage;
-  private HashMap<String, String> logDirs;
-  private HashMap<String, String> topicDirs;
   private Format format;
   private RecordWriterProvider writerProvider;
   private io.confluent.connect.storage.format.RecordWriterProvider<HdfsSinkConnectorConfig>
@@ -108,11 +105,9 @@ public class DataWriter {
       Time time
   ) {
     this.time = time;
-    this.connectorConfig = config;
     this.avroData = avroData;
     this.context = context;
-    topicDirs = new HashMap<>();
-    logDirs = new HashMap<>();
+    connectorConfig = config;
     topicPartitionWriters = new HashMap<>();
 
     try {
@@ -143,18 +138,6 @@ public class DataWriter {
         config,
         connectorConfig.url()
     );
-
-    for (TopicPartition tp : context.assignment()) {
-      String topicDir = connectorConfig.getTopicsDirFromTopic(tp.topic());
-      String logDir = connectorConfig.getLogsDirFromTopic(tp.topic());
-
-      topicDirs.put(tp.topic(), topicDir);
-      logDirs.put(tp.topic(), logDir);
-
-      createDir(topicDir);
-      createDir(topicDir + HdfsSinkConnectorConstants.TEMPFILE_DIRECTORY);
-      createDir(logDir);
-    }
 
     try {
       // Try to instantiate as a new-style storage-common type class, then fall back to old-style
@@ -221,8 +204,6 @@ public class DataWriter {
     if (connectorConfig.hiveIntegrationEnabled()) {
       initializeHiveServices(hadoopConfiguration);
     }
-
-    initializeTopicPartitionWriters(context.assignment());
   }
 
   private void configureKerberosAuthentication(Configuration hadoopConfiguration) {
@@ -322,28 +303,6 @@ public class DataWriter {
     hiveUpdateFutures = new LinkedList<>();
   }
 
-  private void initializeTopicPartitionWriters(Set<TopicPartition> assignment) {
-    for (TopicPartition tp : assignment) {
-      TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-          tp,
-          storage,
-          writerProvider,
-          newWriterProvider,
-          partitioner,
-          connectorConfig,
-          context,
-          avroData,
-          hiveMetaStore,
-          hive,
-          schemaFileReader,
-          executorService,
-          hiveUpdateFutures,
-          time
-      );
-      topicPartitionWriters.put(tp, topicPartitionWriter);
-    }
-  }
-
   public void write(Collection<SinkRecord> records) {
     for (SinkRecord record : records) {
       String topic = record.topic();
@@ -380,50 +339,79 @@ public class DataWriter {
     topicPartitionWriters.get(tp).recover();
   }
 
+  /**
+   * For each partition, get the schema from the latest file and attempt
+   * to create a Hive table from it.
+   */
   public void syncWithHive() throws ConnectException {
-    Set<String> topics = new HashSet<>();
-    for (TopicPartition tp : topicPartitionWriters.keySet()) {
-      topics.add(tp.topic());
-    }
+    // ensure each topic is only synced once
+    Set<String> topics = topicPartitionWriters.keySet()
+        .stream().map(TopicPartition::topic).collect(Collectors.toSet());
 
-    try {
-      for (String topic : topics) {
+    for (String topic : topics) {
+      Path recoveredFileWithMaxOffsets = getLatestFilePathForTopic(topic);
+
+      if (recoveredFileWithMaxOffsets != null) {
+        Schema latestSchema = schemaFileReader
+            .getSchema(connectorConfig, recoveredFileWithMaxOffsets);
+
         String topicDir = FileUtils.topicDirectory(
             connectorConfig.url(),
-            topicDirs.get(topic),
+            connectorConfig.getTopicsDirFromTopic(topic),
             topic
         );
-        CommittedFileFilter filter = new TopicCommittedFileFilter(topic);
-        FileStatus fileStatusWithMaxOffset = FileUtils.fileStatusWithMaxOffset(
-            storage,
-            new Path(topicDir),
-            filter
-        );
-        if (fileStatusWithMaxOffset != null) {
-          final Path path = fileStatusWithMaxOffset.getPath();
-          final Schema latestSchema;
-          latestSchema = schemaFileReader.getSchema(
-              connectorConfig,
-              path
-          );
-          hive.createTable(hiveDatabase, topic, latestSchema, partitioner);
-          List<String> partitions = hiveMetaStore.listPartitions(hiveDatabase, topic, (short) -1);
-          FileStatus[] statuses = FileUtils.getDirectories(storage, new Path(topicDir));
-          for (FileStatus status : statuses) {
-            String location = status.getPath().toString();
-            if (!partitions.contains(location)) {
-              String partitionValue = getPartitionValue(location);
-              hiveMetaStore.addPartition(hiveDatabase, topic, partitionValue);
-            }
-          }
+        attemptCreatingHiveTable(topic, topicDir, latestSchema);
+      }
+    }
+  }
+
+  /**
+   * Attempt to create a Hive table based on a file's schema from the topic.
+   *
+   * @param topic the name of the topic
+   * @param topicDir the directory of the topic
+   * @param latestSchema the schema of the latest file
+   */
+  private void attemptCreatingHiveTable(String topic, String topicDir, Schema latestSchema) {
+    try {
+      hive.createTable(hiveDatabase, topic, latestSchema, partitioner);
+      List<String> partitions = hiveMetaStore.listPartitions(hiveDatabase, topic, (short) -1);
+      FileStatus[] statuses = FileUtils.getDirectories(storage, new Path(topicDir));
+      for (FileStatus status : statuses) {
+        String location = status.getPath().toString();
+        if (!partitions.contains(location)) {
+          String partitionValue = getPartitionValue(location);
+          hiveMetaStore.addPartition(hiveDatabase, topic, partitionValue);
         }
       }
+    } catch (HiveMetaStoreException e) {
+      log.warn("Could not create Hive table: {}", e.getMessage());
     } catch (IOException e) {
       throw new ConnectException(e);
     }
   }
 
+
+  /**
+   * Get the latest file written for a topic. Go through the topic partition writers
+   * for a topic and make use of the already computed latest file in recover.
+   */
+  private Path getLatestFilePathForTopic(String topic) {
+    long greatestOffset = -1;
+    Path latestFilePath = null;
+    for (TopicPartitionWriter tp : topicPartitionWriters.values()) {
+      if (tp.topicPartition().topic().equals(topic)) {
+        if (tp.offset() > greatestOffset) {
+          greatestOffset = tp.offset();
+          latestFilePath = tp.getRecoveredFileWithMaxOffsets();
+        }
+      }
+    }
+    return latestFilePath;
+  }
+
   public void open(Collection<TopicPartition> partitions) {
+    log.debug("Opening DataWriter with partitions: {}", partitions);
     for (TopicPartition tp : partitions) {
       TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
           tp,
@@ -444,7 +432,12 @@ public class DataWriter {
       topicPartitionWriters.put(tp, topicPartitionWriter);
       // We need to immediately start recovery to ensure we pause consumption of messages for the
       // assigned topics while we try to recover offsets and rewind.
-      recover(tp);
+      log.debug("Recovering offsets for partition {}", tp);
+      topicPartitionWriter.recover();
+    }
+
+    if (connectorConfig.hiveIntegrationEnabled()) {
+      syncWithHive();
     }
   }
 
@@ -545,14 +538,6 @@ public class DataWriter {
   public Map<String, String> getTempFileNames(TopicPartition tp) {
     TopicPartitionWriter topicPartitionWriter = topicPartitionWriters.get(tp);
     return topicPartitionWriter.getTempFiles();
-  }
-
-  private void createDir(String dir) {
-    String path = connectorConfig.url() + "/" + dir;
-    if (!storage.exists(path)) {
-      log.trace("Creating directory {}", path);
-      storage.create(path);
-    }
   }
 
   private Partitioner newPartitioner(HdfsSinkConnectorConfig config)

--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -70,6 +70,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     Collection<SinkRecord> sinkRecords = createRecords(PARTITION, 0, 7);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData, time);
+    hdfsWriter.open(context.assignment());
     MemoryStorage storage = (MemoryStorage) hdfsWriter.getStorage();
     storage.setFailure(MemoryStorage.Failure.appendFailure);
 
@@ -113,10 +114,8 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
       (offset < 4 ? sinkRecordsA : sinkRecordsB).add(sinkRecord);
     }
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData, time);
+    hdfsWriter.open(context.assignment());
     MemoryStorage storage = (MemoryStorage) hdfsWriter.getStorage();
-
-    // Simulate a recovery after starting the task
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     hdfsWriter.write(sinkRecordsA);
     // 0,1,2 are committed
@@ -176,6 +175,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     sinkRecords.add(createRecord(PARTITION2, 0));
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData, time);
+    hdfsWriter.open(context.assignment());
     hdfsWriter.write(sinkRecords);
     sinkRecords.clear();
 
@@ -233,6 +233,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
 
     ArrayList<SinkRecord> sinkRecords = createRecords(PARTITION, 0, 1);
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData, time);
+    hdfsWriter.open(context.assignment());
     hdfsWriter.write(sinkRecords);
 
     sinkRecords = createRecords(PARTITION, 1, 6);
@@ -278,6 +279,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
 
     ArrayList<SinkRecord> sinkRecords = createRecords(PARTITION, 0, 1);
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData, time);
+    hdfsWriter.open(context.assignment());
     hdfsWriter.write(sinkRecords);
 
     sinkRecords = createRecords(PARTITION, 1, 6);

--- a/src/test/java/io/confluent/connect/hdfs/FormatAPIDataWriterCompatibilityTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FormatAPIDataWriterCompatibilityTest.java
@@ -32,8 +32,7 @@ public class FormatAPIDataWriterCompatibilityTest extends HiveTestBase {
   @Test
   public void dataWriterNewFormatAPICompatibilityTest() {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     String key = "key";
     Schema schema = createSchema();
@@ -67,8 +66,7 @@ public class FormatAPIDataWriterCompatibilityTest extends HiveTestBase {
   @Test
   public void dataWriterNewFormatAPICompatibilityWithDefaultsTest() {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     String key = "key";
     Schema schema = createSchema();

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
@@ -58,6 +58,7 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
 
     task.initialize(context);
     task.start(properties);
+    task.open(context.assignment());
 
     Map<TopicPartition, Long> offsets = context.offsets();
     assertEquals(offsets.size(), 2);
@@ -99,6 +100,7 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
     HdfsSinkTask task = new HdfsSinkTask();
     task.initialize(context);
     task.start(properties);
+    task.open(context.assignment());
     task.put(sinkRecordsA);
 
     // Get an aliased reference to the filesystem object from the per-worker FileSystem.CACHE
@@ -186,6 +188,7 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
 
     task.initialize(context);
     task.start(properties);
+    task.open(context.assignment());
 
     // Without any files in HDFS, we expect no offsets to be set by the connector.
     // Thus, the consumer will start where it last left off or based upon the
@@ -243,6 +246,7 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
 
     task.initialize(context);
     task.start(properties);
+    task.open(context.assignment());
 
     Map<TopicPartition, Long> offsets = context.offsets();
     assertEquals(2, offsets.size());
@@ -272,6 +276,7 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
     }
     task.initialize(context);
     task.start(properties);
+    task.open(context.assignment());
     task.put(sinkRecords);
     task.stop();
 
@@ -316,6 +321,7 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
     }
     task.initialize(context);
     task.start(properties);
+    task.open(context.assignment());
     task.put(sinkRecords);
     task.stop();
 

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskWithSecureHDFSTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskWithSecureHDFSTest.java
@@ -56,6 +56,7 @@ public class HdfsSinkTaskWithSecureHDFSTest extends TestWithSecureMiniDFSCluster
 
     task.initialize(context);
     task.start(properties);
+    task.open(context.assignment());
     task.put(sinkRecords);
     task.stop();
 

--- a/src/test/java/io/confluent/connect/hdfs/avro/AvroHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/AvroHiveUtilTest.java
@@ -152,7 +152,7 @@ public class AvroHiveUtilTest extends HiveTestBase {
   private void prepareData(String topic, int partition) throws Exception {
     TopicPartition tp = new TopicPartition(topic, partition);
     DataWriter hdfsWriter = createWriter(context, avroData);
-    hdfsWriter.recover(tp);
+    hdfsWriter.open(context.assignment());
 
     List<SinkRecord> sinkRecords = createSinkRecords(7);
 

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -71,8 +71,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   @Test
   public void testWriteRecord() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecords(7);
 
@@ -89,7 +89,6 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   public void testRecovery() throws Exception {
     String topicsDir = this.topicsDir.get(TOPIC_PARTITION.topic());
     fs.delete(new Path(FileUtils.directoryName(url, topicsDir, TOPIC_PARTITION)), true);
-
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
     partitioner = hdfsWriter.getPartitioner();
@@ -110,7 +109,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     wal.append(WAL.endMarker, "");
     wal.close();
 
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
     Map<TopicPartition, Long> offsets = context.offsets();
     assertTrue(offsets.containsKey(TOPIC_PARTITION));
     assertEquals(50L, (long) offsets.get(TOPIC_PARTITION));
@@ -132,6 +131,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
 
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
 
     WAL wal = new FSWAL(logsDir, TOPIC_PARTITION, storage) {
@@ -173,11 +173,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   @Test
   public void testWriteRecordMultiplePartitions() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-
-    for (TopicPartition tp : context.assignment()) {
-      hdfsWriter.recover(tp);
-    }
 
     List<SinkRecord> sinkRecords = createSinkRecords(7, 0, context.assignment());
 
@@ -193,11 +190,9 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   @Test
   public void testWriteInterleavedRecordsInMultiplePartitions() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
 
-    for (TopicPartition tp : context.assignment()) {
-      hdfsWriter.recover(tp);
-    }
 
     List<SinkRecord> sinkRecords = createSinkRecordsInterleaved(7 * context.assignment().size(), 0,
         context.assignment());
@@ -213,6 +208,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   @Test
   public void testWriteInterleavedRecordsInMultiplePartitionsNonZeroInitialOffset() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
 
     List<SinkRecord> sinkRecords = createSinkRecordsInterleaved(7 * context.assignment().size(), 9,
@@ -245,7 +241,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     fs.createNewFile(path);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedOffsets();
 
@@ -260,8 +256,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   @Test
   public void testWriteRecordNonZeroInitialOffset() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecords(7, 3);
 
@@ -277,14 +273,10 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
   @Test
   public void testRebalance() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
 
     Set<TopicPartition> originalAssignment = new HashSet<>(context.assignment());
-    // Starts with TOPIC_PARTITION and TOPIC_PARTITION2
-    for (TopicPartition tp : originalAssignment) {
-      hdfsWriter.recover(tp);
-    }
-
     Set<TopicPartition> nextAssignment = new HashSet<>();
     nextAssignment.add(TOPIC_PARTITION);
     nextAssignment.add(TOPIC_PARTITION3);
@@ -328,8 +320,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecordsWithAlternatingSchemas(7, 0);
 
@@ -347,8 +339,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecordsWithAlternatingSchemas(7, 0);
 
@@ -368,8 +360,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     // By excluding the first element we get a list starting with record having the new schema.
     List<SinkRecord> sinkRecords = createSinkRecordsWithAlternatingSchemas(8, 0).subList(1, 8);
@@ -389,8 +381,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecordsNoVersion(1, 0);
     sinkRecords.addAll(createSinkRecordsWithAlternatingSchemas(7, 0));
@@ -438,9 +430,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
 
     Time time = TopicPartitionWriterTest.MockedWallclockTimestampExtractor.TIME;
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData, time);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecords(NUMBER_OF_RECORDS);
     hdfsWriter.write(sinkRecords);
@@ -466,8 +457,8 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecords(7);
 

--- a/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/HiveIntegrationAvroTest.java
@@ -68,7 +68,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
   public void testSyncWithHiveAvro() throws Exception {
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     String key = "key";
     Schema schema = createSchema();
@@ -90,6 +90,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     HdfsSinkConnectorConfig config = new HdfsSinkConnectorConfig(props);
 
     hdfsWriter = new DataWriter(config, context, avroData);
+    hdfsWriter.open(context.assignment());
     hdfsWriter.syncWithHive();
 
     List<String> expectedColumnNames = new ArrayList<>();
@@ -122,7 +123,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     localProps.put(HiveConfig.HIVE_INTEGRATION_CONFIG, "true");
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     String key = "key";
     Schema schema = createSchema();
@@ -169,7 +170,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     context.assignment().add(TOPIC_WITH_DOTS_PARTITION);
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_WITH_DOTS_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     String key = "key";
     Schema schema = createSchema();
@@ -218,6 +219,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     localProps.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "int");
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
 
     Schema schema = createSchema();
     List<Struct> records = createRecordBatches(schema, batchSize, batchNum);
@@ -299,6 +301,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     localProps.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "country,state");
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
 
     Schema schema = SchemaBuilder.struct()
         .field("count", Schema.INT64_SCHEMA)
@@ -380,6 +383,7 @@ public class HiveIntegrationAvroTest extends HiveTestBase {
     localProps.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, DailyPartitioner.class.getName());
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
 
     String key = "key";
     Schema schema = createSchema();

--- a/src/test/java/io/confluent/connect/hdfs/json/DataWriterJsonTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/json/DataWriterJsonTest.java
@@ -61,8 +61,8 @@ public class DataWriterJsonTest extends TestWithMiniDFSCluster {
   @Test
   public void testWithSchema() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecords(7, 0, context.assignment());
 
@@ -78,8 +78,8 @@ public class DataWriterJsonTest extends TestWithMiniDFSCluster {
   @Test
   public void testNoSchema() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createJsonRecordsWithoutSchema(
         7 * context.assignment().size(),

--- a/src/test/java/io/confluent/connect/hdfs/orc/DataWriterOrcTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/orc/DataWriterOrcTest.java
@@ -55,8 +55,8 @@ public class DataWriterOrcTest extends TestWithMiniDFSCluster {
   @Test
   public void testWriteRecord() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecords(7);
 

--- a/src/test/java/io/confluent/connect/hdfs/orc/HiveIntegrationOrcTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/orc/HiveIntegrationOrcTest.java
@@ -65,7 +65,7 @@ public class HiveIntegrationOrcTest extends HiveTestBase {
   public void testSyncWithHiveOrc() throws Exception {
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     List<SinkRecord> sinkRecords = createSinkRecords(7);
 
@@ -77,7 +77,7 @@ public class HiveIntegrationOrcTest extends HiveTestBase {
     HdfsSinkConnectorConfig config = new HdfsSinkConnectorConfig(createProps());
 
     hdfsWriter = new DataWriter(config, context, avroData);
-    hdfsWriter.syncWithHive();
+    hdfsWriter.open(context.assignment());
 
     Schema schema = createSchema();
     Struct expectedRecord = createRecord(schema);
@@ -113,7 +113,7 @@ public class HiveIntegrationOrcTest extends HiveTestBase {
     setUp();
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     List<SinkRecord> sinkRecords = createSinkRecords(7);
 
@@ -150,6 +150,7 @@ public class HiveIntegrationOrcTest extends HiveTestBase {
     localProps.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "int");
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
 
     Schema schema = createSchema();
     List<Struct> records = createRecordBatches(schema, 3, 3);
@@ -221,6 +222,7 @@ public class HiveIntegrationOrcTest extends HiveTestBase {
     localProps.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, DailyPartitioner.class.getName());
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
 
     Schema schema = createSchema();
     List<Struct> records = createRecordBatches(schema, 3, 3);

--- a/src/test/java/io/confluent/connect/hdfs/orc/OrcHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/orc/OrcHiveUtilTest.java
@@ -151,9 +151,8 @@ public class OrcHiveUtilTest extends HiveTestBase {
   }
 
   private void prepareData(String topic, int partition) {
-    TopicPartition tp = new TopicPartition(topic, partition);
     DataWriter hdfsWriter = createWriter(context, avroData);
-    hdfsWriter.recover(tp);
+    hdfsWriter.open(context.assignment());
     String key = "key";
     Schema schema = createSchema();
     Struct record = createRecord(schema);

--- a/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/DataWriterParquetTest.java
@@ -46,8 +46,8 @@ public class DataWriterParquetTest extends TestWithMiniDFSCluster {
   @Test
   public void testWriteRecord() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createSinkRecords(7);
 

--- a/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
@@ -68,7 +68,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
   public void testSyncWithHiveParquet() throws Exception {
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     List<SinkRecord> sinkRecords = createSinkRecords(7);
 
@@ -80,7 +80,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     HdfsSinkConnectorConfig config = new HdfsSinkConnectorConfig(createProps());
 
     hdfsWriter = new DataWriter(config, context, avroData);
-    hdfsWriter.syncWithHive();
+    hdfsWriter.open(context.assignment());
 
     Schema schema = createSchema();
     Struct expectedRecord = createRecord(schema);
@@ -117,7 +117,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     setUp();
 
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
-    hdfsWriter.recover(TOPIC_PARTITION);
+    hdfsWriter.open(context.assignment());
 
     List<SinkRecord> sinkRecords = createSinkRecords(7);
 
@@ -157,6 +157,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     localProps.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "int");
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
 
     Schema schema = createSchema();
     List<Struct> records = createRecordBatches(schema, batchSize, batchNum);
@@ -238,6 +239,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     localProps.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "country,state");
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
 
     Schema schema = SchemaBuilder.struct()
         .field("count", Schema.INT64_SCHEMA)
@@ -320,6 +322,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     localProps.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, DailyPartitioner.class.getName());
     setUp();
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
 
     Schema schema = createSchema();
     List<Struct> records = createRecordBatches(schema, 3, 3);

--- a/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/ParquetHiveUtilTest.java
@@ -155,7 +155,7 @@ public class ParquetHiveUtilTest extends HiveTestBase {
   private void prepareData(String topic, int partition) {
     TopicPartition tp = new TopicPartition(topic, partition);
     DataWriter hdfsWriter = createWriter(context, avroData);
-    hdfsWriter.recover(tp);
+    hdfsWriter.open(context.assignment());
     String key = "key";
     Schema schema = createSchema();
     Struct record = createRecord(schema);

--- a/src/test/java/io/confluent/connect/hdfs/string/DataWriterStringTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/string/DataWriterStringTest.java
@@ -50,8 +50,8 @@ public class DataWriterStringTest extends TestWithMiniDFSCluster {
   @Test
   public void testReadString() throws Exception {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
+    hdfsWriter.open(context.assignment());
     partitioner = hdfsWriter.getPartitioner();
-    hdfsWriter.recover(TOPIC_PARTITION);
 
     List<SinkRecord> sinkRecords = createStringRecords(
         7 * context.assignment().size(),


### PR DESCRIPTION
## Problem
The connect framework calls `open(Collection<TopicPartition> partitions)` in order to provide the assigned partitions for the task. However, the code is also attempting to fetch the assigned partitions information in `start()` via  `context.assignment()` from the `SinkTaskContext`. This only works for testing purposes as the context passed there is mocked. In the real calls when starting the connector, `context.assignment()` will come in empty in `start()` as the connect framework has not yet assigned the partitions. The partitions are only assigned on `open()`.

This is due to the fact that `context.assigment()` is not initialized until at least one `put()` call has returned, which means that referencing `context.assigment()` in `start()` is incorrect as it will always be empty. This has also resulted in some code blocks being skipped such as `syncwithHive()` where a Hive table is supposed to be created.

## Solution
Revise code to use partitions assigned in `open()` and remove the unused blocks from `start()`. Additionally, revise the tests to use `open()` for partition assignment. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backporting to `10.0.x`. 