### PR TITLE
CCMSG-1072: bump storage-common to include necessary jackson mapper dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.0.4</version>
+        <version>10.0.6</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>


### PR DESCRIPTION
## Problem
updating `storage-common` to include https://github.com/confluentinc/kafka-connect-storage-common/pull/191


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
