### PR TITLE
CCMSG-1202: Use kafka-connect-storage-common:10.1.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.0.6</version>
+        <version>10.1.1</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,11 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>${jackson.mapper.asl.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
             <version>${kafka.connect.storage.common.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>10.1.0</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>10.1.1</kafka.connect.storage.common.version>
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
@@ -170,11 +170,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>${jackson.mapper.asl.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>


### PR DESCRIPTION
## Problem
The current version doesn't package `jackson-mapper-asl` JAR.

It's included as a transitive `test` dependency only:
```
...
[INFO] +- org.apache.hadoop:hadoop-minicluster:jar:2.10.1:test
[INFO] |  +- org.apache.hadoop:hadoop-common:test-jar:tests:2.10.1:test
[INFO] |  |  +- commons-cli:commons-cli:jar:1.2:compile
[INFO] |  |  +- org.apache.commons:commons-math3:jar:3.1.1:compile
[INFO] |  |  +- xmlenc:xmlenc:jar:0.52:compile
[INFO] |  |  +- commons-net:commons-net:jar:3.1:compile
[INFO] |  |  +- javax.servlet:servlet-api:jar:2.5:compile
[INFO] |  |  +- org.mortbay.jetty:jetty:jar:6.1.26:compile
[INFO] |  |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
[INFO] |  |  +- org.mortbay.jetty:jetty-sslengine:jar:6.1.26:compile
[INFO] |  |  +- javax.servlet.jsp:jsp-api:jar:2.1:runtime
[INFO] |  |  +- com.sun.jersey:jersey-core:jar:1.9:compile
[INFO] |  |  +- com.sun.jersey:jersey-json:jar:1.9:compile
[INFO] |  |  |  +- org.codehaus.jettison:jettison:jar:1.1:compile
[INFO] |  |  |  +- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
[INFO] |  |  |  +- org.codehaus.jackson:jackson-jaxrs:jar:1.8.3:compile
[INFO] |  |  |  \- org.codehaus.jackson:jackson-xc:jar:1.8.3:compile
[INFO] |  |  +- com.sun.jersey:jersey-server:jar:1.9:compile
[INFO] |  |  |  \- asm:asm:jar:3.1:compile
[INFO] |  |  +- net.java.dev.jets3t:jets3t:jar:0.9.0:compile
[INFO] |  |  |  \- com.jamesmurty.utils:java-xmlbuilder:jar:0.4:compile
[INFO] |  |  +- commons-lang:commons-lang:jar:2.6:compile
[INFO] |  |  +- commons-configuration:commons-configuration:jar:1.6:compile
[INFO] |  |  +- commons-digester:commons-digester:jar:1.8:compile
[INFO] |  |  +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.13:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.14.jdk17-redhat-00001:compile
...
```

## Solution
Add `jackson-mapper-asl` as a dependency.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
```
$ mvn clean -DskipTests=true package
...
```
```
$ find . -name "jackson-mapper-asl*.jar"
./target/kafka-connect-hdfs-10.0.7-SNAPSHOT-package/share/java/kafka-connect-hdfs/jackson-mapper-asl-1.9.14.jdk17-redhat-00001.jar
./target/components/packages/confluentinc-kafka-connect-hdfs-10.0.7-SNAPSHOT/confluentinc-kafka-connect-hdfs-10.0.7-SNAPSHOT/lib/jackson-mapper-asl-1.9.14.jdk17-redhat-00001.jar
./target/kafka-connect-hdfs-10.0.7-SNAPSHOT-development/share/java/kafka-connect-hdfs/jackson-mapper-asl-1.9.14.jdk17-redhat-00001.jar
```

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
