### PR TITLE
CCMSG-1014: Do not leak fs in io.confluent.connect.hdfs.wal.WALFile.Writer#Writer().

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
+++ b/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
@@ -56,6 +56,7 @@ public class HdfsStorage
   public HdfsStorage(HdfsSinkConnectorConfig conf,  String url) throws IOException {
     this.conf = conf;
     this.url = url;
+    // this creates one entry in org.apache.hadoop.fs.FileSystem.CACHE
     fs = FileSystem.newInstance(URI.create(url), conf.getHadoopConfiguration());
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WALFile.java
@@ -143,6 +143,7 @@ public class WALFile {
       try {
         if (ownStream) {
           Path p = fileOption.getValue();
+          // this creates one entry in org.apache.hadoop.fs.FileSystem.CACHE
           fs = FileSystem.newInstance(p.toUri(), conf);
           int bufferSize = bufferSizeOption == null
                            ? getBufferSize(conf)
@@ -179,10 +180,11 @@ public class WALFile {
         }
 
         init(connectorConfig, out, ownStream);
-      } catch (RemoteException re) {
+      } catch (Exception re) {
         log.warn("Failed creating a WAL Writer: " + re.getMessage());
         if (fs != null) {
           try {
+            //this deletes an entry from org.apache.hadoop.fs.FileSystem.CACHE
             fs.close();
           } catch (Throwable t) {
             log.error("Could not close filesystem", t);
@@ -190,7 +192,6 @@ public class WALFile {
         }
         throw re;
       }
-
     }
     
     private boolean hasIntactVersionHeader(Path p, FileSystem fs) throws IOException {
@@ -331,6 +332,7 @@ public class WALFile {
       } finally {
         if (fs != null) {
           try {
+            //this deletes an entry from org.apache.hadoop.fs.FileSystem.CACHE
             fs.close();
           } catch (Throwable t) {
             log.error("Could not close FileSystem", t);

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
@@ -33,7 +33,6 @@ import java.util.Map;
 
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.hdfs.avro.AvroDataFileReader;
-import io.confluent.connect.hdfs.avro.AvroFileReader;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.storage.StorageFactory;
 import io.confluent.connect.storage.common.StorageCommonConfig;

--- a/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
@@ -31,6 +31,7 @@ import org.junit.After;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -353,6 +354,19 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
                                                      expectedSchema);
       assertEquals(avroData.fromConnectData(expectedSchema, expectedValue), avroRecord);
     }
+  }
+
+  protected int getFileSystemCacheSize() throws Exception {
+    Field cacheField = FileSystem.class.getDeclaredField("CACHE");
+    cacheField.setAccessible(true);
+    Object cache = cacheField.get(Object.class);
+    Field cacheMapField = cache.getClass().getDeclaredField("map");
+    cacheMapField.setAccessible(true);
+    //suppressing the warning since org.apache.hadoop.fs.FileSystem.Cache.Key has package-level visibility
+    @SuppressWarnings("rawtypes") Map cacheMap = (Map) cacheMapField.get(cache);
+    cacheField.setAccessible(false);
+    cacheMapField.setAccessible(false);
+    return cacheMap.size();
   }
 
 }

--- a/src/test/java/io/confluent/connect/hdfs/TestWithSecureMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithSecureMiniDFSCluster.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.File;

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -103,7 +103,8 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     Object cache = cacheField.get(Object.class);
     Field cacheMapField = cache.getClass().getDeclaredField("map");
     cacheMapField.setAccessible(true);
-    Map cacheMap = (Map) cacheMapField.get(cache);
+    //suppressing the warning since org.apache.hadoop.fs.FileSystem.Cache.Key has package-level visibility
+    @SuppressWarnings("rawtypes") Map cacheMap = (Map) cacheMapField.get(cache);
     cacheField.setAccessible(false);
     cacheMapField.setAccessible(false);
     return cacheMap.size();

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -15,14 +15,11 @@
 
 package io.confluent.connect.hdfs.wal;
 
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
 
 import java.io.OutputStream;
-import java.lang.reflect.Field;
-import java.util.Map;
 
 import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
@@ -95,18 +92,5 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     // make sure org.apache.hadoop.fs.FileSystem.CACHE
     // doesn't grow when acquireLease re-throws an exception
     assertEquals(fileSystemCacheSizeBefore, getFileSystemCacheSize());
-  }
-
-  private int getFileSystemCacheSize() throws Exception {
-    Field cacheField = FileSystem.class.getDeclaredField("CACHE");
-    cacheField.setAccessible(true);
-    Object cache = cacheField.get(Object.class);
-    Field cacheMapField = cache.getClass().getDeclaredField("map");
-    cacheMapField.setAccessible(true);
-    //suppressing the warning since org.apache.hadoop.fs.FileSystem.Cache.Key has package-level visibility
-    @SuppressWarnings("rawtypes") Map cacheMap = (Map) cacheMapField.get(cache);
-    cacheField.setAccessible(false);
-    cacheMapField.setAccessible(false);
-    return cacheMap.size();
   }
 }

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -15,17 +15,20 @@
 
 package io.confluent.connect.hdfs.wal;
 
-import io.confluent.connect.hdfs.FileUtils;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
 
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
-import io.confluent.connect.hdfs.storage.Storage;
 
-import java.io.OutputStream;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -71,5 +74,38 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     o.write(61);
     FSWAL wal = new FSWAL("/logs", tp, storage);
     wal.acquireLease();
+  }
+
+  @Test
+  public void testAcquireLeaseThrowsException() throws Exception {
+    setUp();
+    HdfsStorage storage = new HdfsStorage(connectorConfig, url);
+    TopicPartition tp = new TopicPartition("mytopic", 123);
+    //stop HDFS cluster so that WALFile.createWriter() throws an exception
+    cluster.shutdown();
+    FSWAL wal = new FSWAL("/logs", tp, storage);
+    int fileSystemCacheSizeBefore = getFileSystemCacheSize();
+    for (int i = 0; i < 10; i++) {
+      try {
+        wal.acquireLease();
+      } catch (Exception e) {
+        //expected
+      }
+    }
+    // make sure org.apache.hadoop.fs.FileSystem.CACHE
+    // doesn't grow when acquireLease re-throws an exception
+    assertEquals(fileSystemCacheSizeBefore, getFileSystemCacheSize());
+  }
+
+  private int getFileSystemCacheSize() throws Exception {
+    Field cacheField = FileSystem.class.getDeclaredField("CACHE");
+    cacheField.setAccessible(true);
+    Object cache = cacheField.get(Object.class);
+    Field cacheMapField = cache.getClass().getDeclaredField("map");
+    cacheMapField.setAccessible(true);
+    Map cacheMap = (Map) cacheMapField.get(cache);
+    cacheField.setAccessible(false);
+    cacheMapField.setAccessible(false);
+    return cacheMap.size();
   }
 }


### PR DESCRIPTION
## Problem
HDFS client has a cache - `org.apache.hadoop.fs.FileSystem#CACHE`.
It's not automatically cleaned, it requires an explicit cleanup.
In the HDFS sink connector, some actions create new entries in the cache and some clean entries from it(added comments in the code, to make review easier, will remove before merging).

`io.confluent.connect.hdfs.wal.FSWAL#FSWAL` does actions, that create cache entries:
- `append()`
- `acquireLease()`
- `apply()`
- `truncate()`

Whenever we call `org.apache.hadoop.fs.FileSystem#newInstance(java.net.URI, org.apache.hadoop.conf.Configuration)`, it creates one entry in `org.apache.hadoop.fs.FileSystem#CACHE` so it has to be closed when not needed anymore.

There is a `catch` clause in `io.confluent.connect.hdfs.wal.WALFile.Writer#Writer`, that closes `fs` in case there is `RemoteException`.
But, in some cases, it can be another exception(e.g. `java.io.EOFException`, when HDFS is down), we are not catching it and re-throwing an exception.

## Solution
Catch `Exception` instead of `RemoteException` so that we never leak `fs`.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
