### PR TITLE
CCMSG-1344: Import CVE-free htrace-core4 and avatica from kafka-connect-storage-c…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,14 +56,6 @@
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
-        <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>10.0.0</kafka.connect.storage.common.version>
-        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
-        <commons.collections.version>3.2.2</commons.collections.version>
-        <libthrift.version>0.13.0</libthrift.version>
-        <log4j-api.version>2.8.2</log4j-api.version>
-        <htrace-core4.version>10.0.0</htrace-core4.version>
-        <avatica.version>10.0.0</avatica.version>
     </properties>
 
     <repositories>
@@ -133,10 +125,6 @@
                     <artifactId>htrace-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.calcite.avatica</groupId>
-                    <artifactId>avatica</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro-ipc-jetty</artifactId>
                 </exclusion>
@@ -159,12 +147,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
-            <version>${htrace-core4.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-connect-storage-common-avatica-shaded</artifactId>
-            <version>${avatica.version}</version>
+            <version>${confluent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,14 @@
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
+        <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <kafka.connect.storage.common.version>10.0.0</kafka.connect.storage.common.version>
+        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
+        <commons.collections.version>3.2.2</commons.collections.version>
+        <libthrift.version>0.13.0</libthrift.version>
+        <log4j-api.version>2.8.2</log4j-api.version>
+        <htrace-core4.version>10.0.0</htrace-core4.version>
+        <avatica.version>10.0.0</avatica.version>
     </properties>
 
     <repositories>
@@ -116,6 +124,22 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.calcite.avatica</groupId>
+                    <artifactId>avatica</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro-ipc-jetty</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -133,6 +157,16 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
+            <version>${htrace-core4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-common-avatica-shaded</artifactId>
+            <version>${avatica.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hadoop.version}</version>
@@ -145,6 +179,10 @@
                 <exclusion>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -159,6 +197,14 @@
                     the apacheds-jdbm1 bundle, which is not available in maven central-->
                     <groupId>org.apache.directory.jdbm</groupId>
                     <artifactId>apacheds-jdbm1</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Cherry-pick (#529)

* Import CVE-free htrace-core4 and avatica from kafka-connect-storage-common

* Remove additional htrace dependencies

* pinned storage common version 5.56-SNAPSHOT has the cve-free htrace-core4 dependency

## Problem
No class Def error on CP 6.2 with HDFS Connector 5.5.6-SNAPSHOT version
https://confluentinc.atlassian.net/browse/CC-15456

Q: Do we support CP 6.2 with older HDFS versions? 
CP 6.2 currently works with HDFS 10.0.x 

## Solution
Add block to include shaded dependency from storage-common
```
 <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-common-avatica-shaded</artifactId>
             <version>${avatica.version}</version>
         </dependency>
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Tested with [Docker Playground](https://github.com/vdesabou/kafka-docker-playground) using CP 6.2 and local zip version with these changes
Using CP version 6.2.0
CONNECTOR_ZIP =/Users/prathibha/git/go/src/github.com/confluentinc/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-5.5.6-SNAPSHOT.zip

```
 prathibha@C02DV6PDMD6T  ~/git/go/src/github.com/confluentinc/kafka-docker-playground/connect/connect-hdfs2-sink   master  ./hdfs2-sink.sh                            (master|…1)
16:37:33 ℹ️ 💫 Using CP version 6.2.0
16:37:33 ℹ️ 🎓 set TAG environment variable to specify different version
16:37:35 ℹ️ 🚀 CONNECTOR_ZIP is set with /Users/prathibha/git/go/src/github.com/confluentinc/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-5.5.6-SNAPSHOT.zip
16:37:35 ℹ️ 👷 Building Docker image vdesabou/kafka-docker-playground-connect:confluentinc-kafka-connect-hdfs-5.5.6-SNAPSHOT.zip
[+] Building 6.5s (8/8) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                             0.0s
 => => transferring dockerfile: 251B                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:6.2.0                                                                                        0.0s
 => CACHED [1/3] FROM docker.io/vdesabou/kafka-docker-playground-connect:6.2.0                                                                                                   0.0s
 => [internal] load build context                                                                                                                                                1.5s
 => => transferring context: 106.90MB                                                                                                                                            1.5s
 => [2/3] COPY confluentinc-kafka-connect-hdfs-5.5.6-SNAPSHOT.zip /tmp                                                                                                           0.4s
 => [3/3] RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-hdfs-5.5.6-SNAPSHOT.zip                                                                          3.9s
 => exporting to image                                                                                                                                                           0.6s
 => => exporting layers                                                                                                                                                          0.5s
 => => writing image sha256:146d2064c121b5a119b64f75fcbfad8a2ed78e399f43085d48de0ca84401781d                                                                                     0.0s
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:confluentinc-kafka-connect-hdfs-5.5.6-SNAPSHOT.zip                                                           0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
WARNING: Some networks were defined but are not used by any service: common-network
hive-metastore-postgresql uses an image, skipping
datanode uses an image, skipping
namenode uses an image, skipping
presto-coordinator uses an image, skipping
hive-metastore uses an image, skipping
hive-server uses an image, skipping
zookeeper uses an image, skipping
broker uses an image, skipping
schema-registry uses an image, skipping
connect uses an image, skipping
WARNING: Some networks were defined but are not used by any service: common-network
Stopping ksqldb-cli                ... done
Stopping ksqldb-server             ... done
Stopping control-center            ... done
Stopping connect                   ... done
Stopping schema-registry           ... done
Stopping broker                    ... done
Stopping presto-coordinator        ... done
Stopping hive-metastore            ... done
Stopping hive-metastore-postgresql ... done
Stopping namenode                  ... done
Stopping hive-server               ... done
Stopping zookeeper                 ... done
Stopping datanode                  ... done
Removing ksqldb-cli                ... done
Removing ksqldb-server             ... done
Removing control-center            ... done
Removing connect                   ... done
Removing schema-registry           ... done
Removing broker                    ... done
Removing presto-coordinator        ... done
Removing hive-metastore            ... done
Removing hive-metastore-postgresql ... done
Removing namenode                  ... done
Removing hive-server               ... done
Removing zookeeper                 ... done
Removing datanode                  ... done
Removing network plaintext_default
Removing volume plaintext_namenode
Removing volume plaintext_datanode
WARNING: Some networks were defined but are not used by any service: common-network
Docker Compose is now in the Docker CLI, try `docker compose up`

Creating network "plaintext_default" with the default driver
Creating volume "plaintext_namenode" with default driver
Creating volume "plaintext_datanode" with default driver
Creating hive-metastore-postgresql ... done
Creating zookeeper                 ... done
Creating hive-metastore            ... done
Creating datanode                  ... done
Creating namenode                  ... done
Creating hive-server               ... done
Creating presto-coordinator        ... done
Creating broker                    ... done
Creating schema-registry           ... done
Creating connect                   ... done
Creating control-center            ... done
Creating ksqldb-server             ... done
Creating ksqldb-cli                ... done
16:39:24 ℹ️ 🎓To see the actual properties file, use ../../scripts/get-properties.sh <container>
16:39:24 ℹ️ ⚡If you modify a docker-compose file and want to re-create the container(s), use this command:
16:39:24 ℹ️ ⚡source ../../scripts/utils.sh && docker-compose -f ../../environment/plaintext/docker-compose.yml -f /Users/prathibha/git/go/src/github.com/confluentinc/kafka-docker-playground/connect/connect-hdfs2-sink/docker-compose.plaintext.yml --profile control-center --profile ksqldb up -d
16:39:24 ℹ️ Waiting up to 480 seconds for Kafka Connect connect to start
16:41:35 ℹ️ Connect connect has started!
16:41:35 ℹ️ You can use ksqlDB with CLI using:
16:41:35 ℹ️ docker exec -i ksqldb-cli ksql http://ksqldb-server:8088
16:41:35 ℹ️ 📊 JMX metrics are available locally on those ports:
16:41:35 ℹ️     - zookeeper       : 9999
16:41:35 ℹ️     - broker          : 10000
16:41:35 ℹ️     - schema-registry : 10001
16:41:35 ℹ️     - connect         : 10002
16:41:35 ℹ️     - ksqldb-server   : 10003
16:41:48 ℹ️ Creating HDFS Sink connector
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1989  100   863  100  1126   3958   5165 --:--:-- --:--:-- --:--:--  9082
{
  "name": "hdfs-sink",
  "config": {
    "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
    "tasks.max": "1",
    "topics": "test_hdfs",
    "store.url": "hdfs://namenode:8020",
    "flush.size": "3",
    "hadoop.conf.dir": "/etc/hadoop/",
    "partitioner.class": "io.confluent.connect.hdfs.partitioner.FieldPartitioner",
    "partition.field.name": "f1",
    "rotate.interval.ms": "120000",
    "logs.dir": "/tmp",
    "hive.integration": "true",
    "hive.metastore.uris": "thrift://hive-metastore:9083",
    "hive.database": "testhive",
    "confluent.license": "",
    "confluent.topic.bootstrap.servers": "broker:9092",
    "confluent.topic.replication.factor": "1",
    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
    "value.converter": "io.confluent.connect.avro.AvroConverter",
    "value.converter.schema.registry.url": "http://schema-registry:8081",
    "schema.compatibility": "BACKWARD",
    "name": "hdfs-sink"
  },
  "tasks": [],
  "type": "sink"
}
16:41:48 ℹ️ Sending messages to topic test_hdfs
16:42:01 ℹ️ Listing content of /topics/test_hdfs in HDFS
Found 10 items
drwxrwxrwx   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value1
drwxrwxrwx   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value10
drwxrwxrwx   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value2
drwxrwxrwx   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value3
drwxrwxrwx   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value4
drwxr-xr-x   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value5
drwxr-xr-x   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value6
drwxr-xr-x   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value7
drwxr-xr-x   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value8
drwxr-xr-x   - appuser supergroup          0 2021-08-19 23:41 /topics/test_hdfs/f1=value9
16:42:04 ℹ️ Getting one of the avro files locally and displaying content with avro-tools
log4j:WARN No appenders could be found for logger (org.apache.hadoop.metrics2.lib.MutableMetricsFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
{"f1":"value1"}
16:42:10 ℹ️ Check data with beeline
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/hive/lib/log4j-slf4j-impl-2.6.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/hadoop-2.7.4/share/hadoop/common/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Beeline version 2.3.2 by Apache Hive
beeline> !connect jdbc:hive2://hive-server:10000/testhive
Connecting to jdbc:hive2://hive-server:10000/testhive
Enter username for jdbc:hive2://hive-server:10000/testhive: hive
Enter password for jdbc:hive2://hive-server:10000/testhive: ****
Connected to: Apache Hive (version 2.3.2)
Driver: Hive JDBC (version 2.3.2)
Transaction isolation: TRANSACTION_REPEATABLE_READ
0: jdbc:hive2://hive-server:10000/testhive> show create table test_hdfs;
+----------------------------------------------------+
|                   createtab_stmt                   |
+----------------------------------------------------+
| CREATE EXTERNAL TABLE `test_hdfs`(                 |
|   `f1` string COMMENT '')                          |
| PARTITIONED BY (                                   |
|   `f1` string COMMENT '')                          |
| ROW FORMAT SERDE                                   |
|   'org.apache.hadoop.hive.serde2.avro.AvroSerDe'   |
| STORED AS INPUTFORMAT                              |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'  |
| OUTPUTFORMAT                                       |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' |
| LOCATION                                           |
|   'hdfs://namenode:8020/topics/test_hdfs'          |
| TBLPROPERTIES (                                    |
|   'avro.schema.literal'='{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}],"connect.version":1,"connect.name":"myrecord"}',  |
|   'transient_lastDdlTime'='1629416515')            |
+----------------------------------------------------+
15 rows selected (2.14 seconds)
0: jdbc:hive2://hive-server:10000/testhive> select * from test_hdfs;
+---------------+
| test_hdfs.f1  |
+---------------+
| value1        |
| value2        |
| value3        |
| value4        |
| value5        |
| value6        |
| value7        |
| value8        |
| value9        |
+---------------+
9 rows selected (2.659 seconds)
0: jdbc:hive2://hive-server:10000/testhive> Closing: 0: jdbc:hive2://hive-server:10000/testhive
| value1        |
```

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
