### PR TITLE
CCMSG-1344: Use htrace shaded dependency 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,11 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hadoop.version}</version>


### PR DESCRIPTION
## Problem
Rebasing https://github.com/confluentinc/kafka-connect-hdfs/pull/585 for 5.2.x


## Solution

Import htrace shaded dependency as seperate package
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Tested with docker playground
```

 prathibha@C02DV6PDMD6T  ~/git/go/src/github.com/confluentinc/kafka-docker-playground   master export CONNECTOR_ZIP=/Users/prathibha/git/go/src/github.com/confluentinc/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-5.2.6-SNAPSHOT.zip
 prathibha@C02DV6PDMD6T  ~/git/go/src/github.com/confluentinc/kafka-docker-playground/connect/connect-hdfs2-sink   master ./hdfs2-sink.sh
18:11:58 ℹ️ 💫 Using CP version 6.2.0
18:11:58 ℹ️ 🎓 set TAG environment variable to specify different version
18:12:00 ℹ️ 🚀 CONNECTOR_ZIP is set with /Users/prathibha/git/go/src/github.com/confluentinc/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-5.2.6-SNAPSHOT.zip
18:12:00 ℹ️ 👷 Building Docker image vdesabou/kafka-docker-playground-connect:confluentinc-kafka-connect-hdfs-5.2.6-SNAPSHOT.zip
[+] Building 7.7s (8/8) FINISHED
 => [internal] load build definition from Dockerfile                       0.0s
 => => transferring dockerfile: 251B                                       0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playgrou  0.0s
 => [internal] load build context                                          1.5s
 => => transferring context: 113.81MB                                      1.5s
 => CACHED [1/3] FROM docker.io/vdesabou/kafka-docker-playground-connect:  0.0s
 => [2/3] COPY confluentinc-kafka-connect-hdfs-5.2.6-SNAPSHOT.zip /tmp     0.7s
 => [3/3] RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-c  4.8s
 => exporting to image                                                     0.7s
 => => exporting layers                                                    0.5s
 => => writing image sha256:b241cff14b1c27408e428c0143cfd184bcb536b777daf  0.0s
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:confl  0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
WARNING: Some networks were defined but are not used by any service: common-network
hive-server uses an image, skipping
hive-metastore-postgresql uses an image, skipping
zookeeper uses an image, skipping
broker uses an image, skipping
schema-registry uses an image, skipping
namenode uses an image, skipping
datanode uses an image, skipping
hive-metastore uses an image, skipping
presto-coordinator uses an image, skipping
connect uses an image, skipping
WARNING: Some networks were defined but are not used by any service: common-network
Stopping ksqldb-cli                ... done
Stopping control-center            ... done
Stopping ksqldb-server             ... done
Stopping connect                   ... done
Stopping schema-registry           ... done
Stopping broker                    ... done
Stopping presto-coordinator        ... done
Stopping namenode                  ... done
Stopping hive-metastore            ... done
Stopping hive-server               ... done
Stopping hive-metastore-postgresql ... done
Stopping datanode                  ... done
Stopping zookeeper                 ... done
Removing ksqldb-cli                ... done
Removing control-center            ... done
Removing ksqldb-server             ... done
Removing connect                   ... done
Removing schema-registry           ... done
Removing broker                    ... done
Removing presto-coordinator        ... done
Removing namenode                  ... done
Removing hive-metastore            ... done
Removing hive-server               ... done
Removing hive-metastore-postgresql ... done
Removing datanode                  ... done
Removing zookeeper                 ... done
Removing network plaintext_default
Removing volume plaintext_namenode
Removing volume plaintext_datanode
WARNING: Some networks were defined but are not used by any service: common-network
Docker Compose is now in the Docker CLI, try `docker compose up`

Creating network "plaintext_default" with the default driver
Creating volume "plaintext_namenode" with default driver
Creating volume "plaintext_datanode" with default driver
Creating presto-coordinator        ... done
Creating hive-metastore-postgresql ... done
Creating hive-metastore            ... done
Creating zookeeper                 ... done
Creating namenode                  ... done
Creating hive-server               ... done
Creating datanode                  ... done
Creating broker                    ... done
Creating schema-registry           ... done
Creating connect                   ... done
Creating control-center            ... done
Creating ksqldb-server             ... done
Creating ksqldb-cli                ... done
18:13:30 ℹ️ 🎓To see the actual properties file, use ../../scripts/get-properties.sh <container>
18:13:30 ℹ️ ⚡If you modify a docker-compose file and want to re-create the container(s), use this command:
18:13:30 ℹ️ ⚡source ../../scripts/utils.sh && docker-compose -f ../../environment/plaintext/docker-compose.yml -f /Users/prathibha/git/go/src/github.com/confluentinc/kafka-docker-playground/connect/connect-hdfs2-sink/docker-compose.plaintext.yml --profile control-center --profile ksqldb up -d
18:13:30 ℹ️ Waiting up to 480 seconds for Kafka Connect connect to start
18:13:52 ℹ️ Connect connect has started!
18:13:52 ℹ️ You can use ksqlDB with CLI using:
18:13:52 ℹ️ docker exec -i ksqldb-cli ksql http://ksqldb-server:8088
18:13:52 ℹ️ 📊 JMX metrics are available locally on those ports:
18:13:52 ℹ️     - zookeeper       : 9999
18:13:52 ℹ️     - broker          : 10000
18:13:52 ℹ️     - schema-registry : 10001
18:13:52 ℹ️     - connect         : 10002
18:13:52 ℹ️     - ksqldb-server   : 10003
18:14:05 ℹ️ Creating HDFS Sink connector
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1989  100   863  100  1126   5427   7081 --:--:-- --:--:-- --:--:-- 12509
{
  "name": "hdfs-sink",
  "config": {
    "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
    "tasks.max": "1",
    "topics": "test_hdfs",
    "store.url": "hdfs://namenode:8020",
    "flush.size": "3",
    "hadoop.conf.dir": "/etc/hadoop/",
    "partitioner.class": "io.confluent.connect.hdfs.partitioner.FieldPartitioner",
    "partition.field.name": "f1",
    "rotate.interval.ms": "120000",
    "logs.dir": "/tmp",
    "hive.integration": "true",
    "hive.metastore.uris": "thrift://hive-metastore:9083",
    "hive.database": "testhive",
    "confluent.license": "",
    "confluent.topic.bootstrap.servers": "broker:9092",
    "confluent.topic.replication.factor": "1",
    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
    "value.converter": "io.confluent.connect.avro.AvroConverter",
    "value.converter.schema.registry.url": "http://schema-registry:8081",
    "schema.compatibility": "BACKWARD",
    "name": "hdfs-sink"
  },
  "tasks": [],
  "type": "sink"
}
18:14:05 ℹ️ Sending messages to topic test_hdfs
18:14:18 ℹ️ Listing content of /topics/test_hdfs in HDFS
Found 10 items
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value1
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value10
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value2
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value3
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value4
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value5
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value6
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value7
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value8
drwxr-xr-x   - appuser supergroup          0 2021-09-09 01:14 /topics/test_hdfs/f1=value9
18:14:20 ℹ️ Getting one of the avro files locally and displaying content with avro-tools
log4j:WARN No appenders could be found for logger (org.apache.hadoop.metrics2.lib.MutableMetricsFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
{"f1":"value1"}
18:14:26 ℹ️ Check data with beeline
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/hive/lib/log4j-slf4j-impl-2.6.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/hadoop-2.7.4/share/hadoop/common/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Beeline version 2.3.2 by Apache Hive
beeline> !connect jdbc:hive2://hive-server:10000/testhive
Connecting to jdbc:hive2://hive-server:10000/testhive
Enter username for jdbc:hive2://hive-server:10000/testhive: hive
Enter password for jdbc:hive2://hive-server:10000/testhive: ****
Connected to: Apache Hive (version 2.3.2)
Driver: Hive JDBC (version 2.3.2)
Transaction isolation: TRANSACTION_REPEATABLE_READ
0: jdbc:hive2://hive-server:10000/testhive> show create table test_hdfs;
+----------------------------------------------------+
|                   createtab_stmt                   |
+----------------------------------------------------+
| CREATE EXTERNAL TABLE `test_hdfs`(                 |
|   `f1` string COMMENT '')                          |
| PARTITIONED BY (                                   |
|   `f1` string COMMENT '')                          |
| ROW FORMAT SERDE                                   |
|   'org.apache.hadoop.hive.serde2.avro.AvroSerDe'   |
| STORED AS INPUTFORMAT                              |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'  |
| OUTPUTFORMAT                                       |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' |
| LOCATION                                           |
|   'hdfs://namenode:8020/topics/test_hdfs'          |
| TBLPROPERTIES (                                    |
|   'avro.schema.literal'='{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}],"connect.version":1,"connect.name":"myrecord"}',  |
|   'transient_lastDdlTime'='1631150051')            |
+----------------------------------------------------+
15 rows selected (1.728 seconds)
0: jdbc:hive2://hive-server:10000/testhive> select * from test_hdfs;
+---------------+
| test_hdfs.f1  |
+---------------+
| value1        |
| value2        |
| value3        |
| value4        |
| value5        |
| value6        |
| value7        |
| value8        |
| value9        |
+---------------+
9 rows selected (2.321 seconds)
0: jdbc:hive2://hive-server:10000/testhive> Closing: 0: jdbc:hive2://hive-server:10000/testhive
| value1        |
```

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
