### PR TITLE
Update Jenkinsfile Nodelabel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@
 common {
   slackChannel = '#connect-warn'
   upstreamProjects = ['confluentinc/schema-registry','confluentinc/common']
-  nodeLabel = 'docker-oraclejdk8'
+  nodeLabel = 'docker-debian-jdk8'
 }


### PR DESCRIPTION
## Problem
Using old nodelabel for old docker build image.

## Solution
We are moving to new JDK8 Build Image. This is no longer oracle jdk8 rather adoptopenjdk8 so the nodelabel is more generalized.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
All branches to master.

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
This will be pint merged to master.
<!-- If you are reverting or rolling back, is it safe? --> 
