### PR TITLE
CCMSG-1406 | Exclude netty codec dependency for CVE fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,10 @@
                     <artifactId>netty-all</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.htrace</groupId>
                     <artifactId>htrace-core4</artifactId>
                 </exclusion>


### PR DESCRIPTION
## Problem
CVE fix for netty codec 4.1.63.Final

## Solution
Netty codec dependency is excluded from a transitive pull.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
