### PR TITLE
Bump up the dependency for log4j to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
             <version>${log4j-api.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+            <version>3.4.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
-        <log4j-api.version>2.8.2</log4j-api.version>
+        <log4j-api.version>2.15.0</log4j-api.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>
@@ -159,6 +159,11 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
+            <version>${log4j-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j-api.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Security Vulnerability in log4j dependency. Versions 2.15.0+ are acceptable.

## Problem

Security Vulnerability in log4j dependency - log4j-api-2.8.2.jar and log4j-core-2.8.2.jar
Versions 2.15.0+ are acceptable.


## Solution
(by following example from https://github.com/confluentinc/kafka-connect-gcp-dataproc/pull/65)

Bump up log4j-api alongside the corresponding slf4j dependency (log4j-slf4j-impl) as certain classes (ex ReflectionUtil) are deprecated in 2.14.0 - we need to be at 2.15.0.

Also bumping for com.lmax:disruptor dependency from 3.3.0 to 3.4.2, similar to dataproc



<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
