### PR TITLE
CC-15907 Update log4j to use confluent-log4j version 1.2.17-cp2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <properties>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
+        <confluent-log4j.version>1.2.17-cp2.2</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
     </properties>
 
@@ -132,6 +133,19 @@
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- Use a repackaged version of log4j with security patches.
+                     kafka-connect-storage-hive brings in log4j as a transitive dependency -->
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+            <version>${confluent-log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -144,6 +158,12 @@
                     the apacheds-jdbm1 bundle, which is not available in maven central-->
                     <groupId>org.apache.directory.jdbm</groupId>
                     <artifactId>apacheds-jdbm1</artifactId>
+                </exclusion>
+                <!-- Use a repackaged version of log4j with security patches.
+                     kafka-connect-storage-hive brings in log4j as a transitive dependency -->
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
## Problem

 Update log4j to use confluent-log4j version 1.2.17-cp2.2

```bash
mvn dependency:tree  | grep log4j
[INFO] |  |  +- log4j:apache-log4j-extras:jar:1.2.17:compile
[INFO] +- io.confluent:confluent-log4j:jar:1.2.17-cp2.2:compile
[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.7.26:compile
```

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy

```bash
[colivier@chriso-monster:kafka-connect-hdfs (colivier/5.3.x)]mvn dependency:tree | grep log4j
[INFO] |  |  +- log4j:apache-log4j-extras:jar:1.2.17:compile
[INFO] +- io.confluent:confluent-log4j:jar:1.2.17-cp2.2:compile
[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.7.26:compile
```

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
