### PR TITLE
CCMSG-2015: Address CVEs with hadoop verision 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.8</version>
+        <version>11.0.9</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -57,7 +57,7 @@
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>11.0.8</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>11.0.9</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
@@ -285,6 +285,19 @@
             <groupId>org.apache.directory.jdbm</groupId>
             <artifactId>apacheds-jdbm1</artifactId>
             <version>${apacheds-jdbm1.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- We need to add these dependencies for test -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.28.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Problem

Hadoop version 2.10.1 has the following CVEs. 

https://confluentinc.atlassian.net/browse/CCMSG-2025
https://confluentinc.atlassian.net/browse/CCMSG-2023
https://confluentinc.atlassian.net/browse/CCMSG-2017
https://confluentinc.atlassian.net/browse/CCMSG-2015

## Solution

The version of hadoop was upgraded in https://github.com/confluentinc/kafka-connect-storage-common/pull/253. Bumping up the parent pom version here.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
