### PR TITLE
CCMSG-1906: Address CVEs for ant, jsp, groovy, derby, netty and orc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.5</version>
+        <version>11.0.6</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -57,7 +57,7 @@
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>11.0.5</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>11.0.6</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>


### PR DESCRIPTION
## Problem
The following CVEs were scanned by a customer.

https://confluentinc.atlassian.net/browse/CCMSG-1900
https://confluentinc.atlassian.net/browse/CCMSG-1901
https://confluentinc.atlassian.net/browse/CCMSG-1904
https://confluentinc.atlassian.net/browse/CCMSG-1908
https://confluentinc.atlassian.net/browse/CCMSG-1910
https://confluentinc.atlassian.net/browse/CCMSG-1912

## Solution
Since all of these dependencies are brought in through hive we have to override those dependencies through dependency management. Some of the dependencies can be removed. The changes were done in storage-common in https://github.com/confluentinc/kafka-connect-storage-common/pull/238 and the version is bumped here.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
