### PR TITLE
CCMSG-1794 | CVE fix for guava dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,12 @@
             <version>${kafka.connect.storage.common.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hadoop.version}</version>


### PR DESCRIPTION
we cant go to v30+ due to incompatible interfaces. v18 is a lot older google library
and we know this is only used in tests so we explicitly mark the dependency to test scope thereby dodging the CVE

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests - Docker Playground

`CONNECTOR_ZIP=/Users/parag.badani/git/go/src/github.com/confluentinc/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-10.1.9-SNAPSHOT.zip ./hdfs2-source
`

```
16:11:24 ℹ️ 💫 Using default CP version 7.1.1
16:11:24 ℹ️ 🎓 set TAG environment variable to specify different version, see https://kafka-docker-playground.io/#/how-to-use?id=🎯-for-confluent-platform-cp
16:11:24 ℹ️ 👷🛠 Re-building Docker image vdesabou/kafka-docker-playground-connect:7.1.1 to include confluentinc/kafka-connect-hdfs:latest
[+] Building 39.8s (6/6) FINISHED                                                                                                                                                                                       
 => [internal] load build definition from Dockerfile                                                                                                                                                               0.0s
 => => transferring dockerfile: 173B                                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                                          0.0s
 => CACHED [1/2] FROM docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                                                     0.0s
 => [2/2] RUN confluent-hub install --no-prompt confluentinc/kafka-connect-hdfs:latest                                                                                                                            39.0s
 => exporting to image                                                                                                                                                                                             0.7s 
 => => exporting layers                                                                                                                                                                                            0.7s 
 => => writing image sha256:999bb9cad777ef0f6ca98ac35436cf897b98928580415c3f5d7bfbda23f73c2b                                                                                                                       0.0s 
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                                                          0.0s 
                                                                                                                                                                                                                        
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them                                                                                                                    
16:12:07 ℹ️ 🎯 CONNECTOR_ZIP is set with /Users/parag.badani/git/go/src/github.com/confluentinc/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-10.1.9-SNAPSHOT.zip
16:12:07 ℹ️ 👷 Building Docker image vdesabou/kafka-docker-playground-connect:CP-7.1.1-confluentinc-kafka-connect-hdfs-10.1.9-SNAPSHOT.zip
[+] Building 7.5s (8/8) FINISHED                                                                                                                                                                                        
 => [internal] load build definition from Dockerfile                                                                                                                                                               0.0s
 => => transferring dockerfile: 277B                                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                                          0.0s
 => [1/3] FROM docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                                                            0.1s
 => [internal] load build context                                                                                                                                                                                  2.0s
 => => transferring context: 161.55MB                                                                                                                                                                              2.0s
 => [2/3] COPY --chown=appuser:appuser confluentinc-kafka-connect-hdfs-10.1.9-SNAPSHOT.zip /tmp                                                                                                                    0.4s
 => [3/3] RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-hdfs-10.1.9-SNAPSHOT.zip                                                                                                           4.3s
 => exporting to image                                                                                                                                                                                             0.7s 
 => => exporting layers                                                                                                                                                                                            0.7s 
 => => writing image sha256:0129ab15f3c9ef39a69d657671913cc2f6f450808664aa20f5771e059a9a7832                                                                                                                       0.0s 
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:CP-7.1.1-confluentinc-kafka-connect-hdfs-10.1.9-SNAPSHOT.zip                                                                                   0.0s 
                                                                                                                                                                                                                        
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them                                                                                                                    
16:12:17 ℹ️ 🛑 Grafana is disabled
WARNING: Some networks were defined but are not used by any service: common-network
presto-coordinator uses an image, skipping
namenode uses an image, skipping
datanode uses an image, skipping
hive-server uses an image, skipping
hive-metastore-postgresql uses an image, skipping
zookeeper uses an image, skipping
hive-metastore uses an image, skipping
broker uses an image, skipping
schema-registry uses an image, skipping
connect uses an image, skipping
WARNING: Some networks were defined but are not used by any service: common-network
Stopping ksqldb-cli                ... done
Stopping ksqldb-server             ... done
Stopping control-center            ... done
Stopping connect                   ... done
Stopping schema-registry           ... done
Stopping zookeeper                 ... done
Stopping broker                    ... done
Stopping datanode                  ... done
Stopping presto-coordinator        ... done
Stopping hive-server               ... done
Stopping namenode                  ... done
Stopping hive-metastore            ... done
Stopping hive-metastore-postgresql ... done
Removing ksqldb-cli                ... done
Removing ksqldb-server             ... done
Removing control-center            ... done
Removing connect                   ... done
Removing schema-registry           ... done
Removing zookeeper                 ... done
Removing broker                    ... done
Removing datanode                  ... done
Removing presto-coordinator        ... done
Removing hive-server               ... done
Removing namenode                  ... done
Removing hive-metastore            ... done
Removing hive-metastore-postgresql ... done
Removing network plaintext_default
Removing volume plaintext_namenode
Removing volume plaintext_datanode
WARNING: Some networks were defined but are not used by any service: common-network
Docker Compose is now in the Docker CLI, try `docker compose up`

Creating network "plaintext_default" with the default driver
Creating volume "plaintext_namenode" with default driver
Creating volume "plaintext_datanode" with default driver
Creating namenode                  ... done
Creating presto-coordinator        ... done
Creating zookeeper                 ... done
Creating hive-metastore-postgresql ... done
Creating datanode                  ... done
Creating hive-server               ... done
Creating hive-metastore            ... done
Creating broker                    ... done
Creating schema-registry           ... done
Creating connect                   ... done
Creating control-center            ... done
Creating ksqldb-server             ... done
Creating ksqldb-cli                ... done
16:13:29 ℹ️ 📝 To see the actual properties file, use ../../scripts/get-properties.sh <container>
16:13:29 ℹ️ ✨ If you modify a docker-compose file and want to re-create the container(s), run ../../scripts/recreate-containers.sh or use this command:
16:13:29 ℹ️ ✨ source ../../scripts/utils.sh && docker-compose -f ../../environment/plaintext/docker-compose.yml -f /Users/parag.badani/git/go/src/github.com/confluentinc/kafka-docker-playground/connect/connect-hdfs2-sink/docker-compose.plaintext.yml --profile control-center --profile ksqldb   up -d
16:13:29 ℹ️ ⌛ Waiting up to 480 seconds for connect to start
16:13:50 ℹ️ 🚦 connect is started!
16:13:50 ℹ️ 🔧 You can use ksqlDB with CLI using:
16:13:50 ℹ️ docker exec -i ksqldb-cli ksql http://ksqldb-server:8088
16:13:50 ℹ️ 📊 JMX metrics are available locally on those ports:
16:13:50 ℹ️     - zookeeper       : 9999
16:13:50 ℹ️     - broker          : 10000
16:13:50 ℹ️     - schema-registry : 10001
16:13:50 ℹ️     - connect         : 10002
16:13:50 ℹ️     - ksqldb-server   : 10003
16:14:02 ℹ️ Creating HDFS Sink connector
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1710  100   749  100   961   4907   6296 --:--:-- --:--:-- --:--:-- 12127
{
  "name": "hdfs-sink",
  "config": {
    "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
    "tasks.max": "1",
    "topics": "test_hdfs",
    "store.url": "hdfs://namenode:8020",
    "flush.size": "3",
    "hadoop.conf.dir": "/etc/hadoop/",
    "partitioner.class": "io.confluent.connect.hdfs.partitioner.FieldPartitioner",
    "partition.field.name": "f1",
    "rotate.interval.ms": "120000",
    "logs.dir": "/tmp",
    "hive.integration": "true",
    "hive.metastore.uris": "thrift://hive-metastore:9083",
    "hive.database": "testhive",
    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
    "value.converter": "io.confluent.connect.avro.AvroConverter",
    "value.converter.schema.registry.url": "http://schema-registry:8081",
    "schema.compatibility": "BACKWARD",
    "name": "hdfs-sink"
  },
  "tasks": [],
  "type": "sink"
}
16:14:02 ℹ️ Sending messages to topic test_hdfs
16:14:15 ℹ️ Listing content of /topics/test_hdfs in HDFS
Found 10 items
drwxrwxrwx   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value1
drwxrwxrwx   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value10
drwxrwxrwx   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value2
drwxrwxrwx   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value3
drwxrwxrwx   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value4
drwxrwxrwx   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value5
drwxr-xr-x   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value6
drwxrwxrwx   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value7
drwxr-xr-x   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value8
drwxr-xr-x   - appuser supergroup          0 2022-05-25 10:44 /topics/test_hdfs/f1=value9
16:14:17 ℹ️ Getting one of the avro files locally and displaying content with avro-tools
log4j:WARN No appenders could be found for logger (org.apache.hadoop.metrics2.lib.MutableMetricsFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
{"f1":"value1"}
16:14:20 ℹ️ Check data with beeline
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/hive/lib/log4j-slf4j-impl-2.6.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/hadoop-2.7.4/share/hadoop/common/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Beeline version 2.3.2 by Apache Hive
beeline> !connect jdbc:hive2://hive-server:10000/testhive
Connecting to jdbc:hive2://hive-server:10000/testhive
Enter username for jdbc:hive2://hive-server:10000/testhive: hive
Enter password for jdbc:hive2://hive-server:10000/testhive: ****
Connected to: Apache Hive (version 2.3.2)
Driver: Hive JDBC (version 2.3.2)
Transaction isolation: TRANSACTION_REPEATABLE_READ
0: jdbc:hive2://hive-server:10000/testhive> show create table test_hdfs;
+----------------------------------------------------+
|                   createtab_stmt                   |
+----------------------------------------------------+
| CREATE EXTERNAL TABLE `test_hdfs`(                 |
| )                                                  |
| PARTITIONED BY (                                   |
|   `f1` string COMMENT '')                          |
| ROW FORMAT SERDE                                   |
|   'org.apache.hadoop.hive.serde2.avro.AvroSerDe'   |
| STORED AS INPUTFORMAT                              |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'  |
| OUTPUTFORMAT                                       |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' |
| LOCATION                                           |
|   'hdfs://namenode:8020/topics/test_hdfs'          |
| TBLPROPERTIES (                                    |
|   'avro.schema.literal'='{"type":"record","name":"ConnectDefault","namespace":"io.confluent.connect.avro","fields":[]}',  |
|   'transient_lastDdlTime'='1653475448')            |
+----------------------------------------------------+
15 rows selected (0.987 seconds)
0: jdbc:hive2://hive-server:10000/testhive> select * from test_hdfs;
+---------------+
| test_hdfs.f1  |
+---------------+
| value1        |
| value2        |
| value3        |
| value4        |
| value5        |
| value6        |
| value7        |
| value8        |
| value9        |
+---------------+
9 rows selected (1.622 seconds)
0: jdbc:hive2://hive-server:10000/testhive> Closing: 0: jdbc:hive2://hive-server:10000/testhive
| value1        |
```

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
