### PR TITLE
CCMSG-1793: Update dependencies to fix protobuf cve and integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>10.1.1</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>10.1.10</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j-api.version>2.8.2</log4j-api.version>
@@ -263,7 +263,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.1.10</version>
+        <version>10.1.11</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -57,7 +57,7 @@
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>10.1.10</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>10.1.11</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.1.2</version>
+        <version>10.1.10</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -60,7 +60,7 @@
         <kafka.connect.storage.common.version>10.1.10</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
-        <log4j-api.version>2.8.2</log4j-api.version>
+        <log4j2-api.version>2.17.1</log4j2-api.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>
@@ -122,10 +122,6 @@
                 </exclusion>
                 <exclusion>
                     <groupId>io.netty</groupId>
-                    <artifactId>netty-all</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
                     <artifactId>netty-codec</artifactId>
                 </exclusion>
                 <exclusion>
@@ -165,7 +161,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
-            <version>${log4j-api.version}</version>
+            <version>${log4j2-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2-api.version}</version>
             <exclusions>
                 <!-- Use a repackaged version of log4j with security patches.
                      kafka-connect-storage-hive brings in log4j as a transitive dependency -->
@@ -176,18 +177,26 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j2-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+            <version>3.4.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-druid</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>${commons.collections.version}</version>


### PR DESCRIPTION
## Problem
Current kafka connect storage common uses protobuf-java 3.1.0 which has a vulnerability.

## Solution
Updated kafka connect storage common version to fix the CVE

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

Docker playground output:
```
➜  connect-hdfs2-sink git:(master) ✗ CONNECTOR_ZIP=/Users/ajain/projects/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip ./hdfs2-sink.sh
20:17:08 ℹ️ 💫 Using default CP version 7.1.1
20:17:08 ℹ️ 🎓 set TAG environment variable to specify different version, see https://kafka-docker-playground.io/#/how-to-use?id=🎯-for-confluent-platform-cp
20:17:08 ℹ️ 👷🛠 Re-building Docker image vdesabou/kafka-docker-playground-connect:7.1.1 to include confluentinc/kafka-connect-hdfs:latest
[+] Building 53.9s (6/6) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                   0.2s
 => => transferring dockerfile: 173B                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                      0.1s
 => => transferring context: 2B                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                              0.0s
 => CACHED [1/2] FROM docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                                         0.0s
 => [2/2] RUN confluent-hub install --no-prompt confluentinc/kafka-connect-hdfs:latest                                                                                                                52.5s
 => exporting to image                                                                                                                                                                                 1.1s
 => => exporting layers                                                                                                                                                                                1.0s
 => => writing image sha256:28c71b579df2d343b5171fa80f17700e17030be7be2d8052406519be86b504cb                                                                                                           0.0s
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                                              0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
20:18:07 ℹ️ 🎯 CONNECTOR_ZIP is set with /Users/ajain/projects/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip
20:18:07 ℹ️ 👷 Building Docker image vdesabou/kafka-docker-playground-connect:CP-7.1.1-confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip
[+] Building 11.8s (8/8) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                   0.0s
 => => transferring dockerfile: 277B                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                              0.0s
 => [internal] load build context                                                                                                                                                                      3.3s
 => => transferring context: 168.78MB                                                                                                                                                                  3.3s
 => [1/3] FROM docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                                                0.3s
 => [2/3] COPY --chown=appuser:appuser confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip /tmp                                                                                                        0.7s
 => [3/3] RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip                                                                                               6.7s
 => exporting to image                                                                                                                                                                                 1.0s
 => => exporting layers                                                                                                                                                                                0.9s
 => => writing image sha256:40d5b3bc0f5d9ed6a6c706986bc4993d351cbd2e199ec4d39393f23dddf228e6                                                                                                           0.0s
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:CP-7.1.1-confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip                                                                       0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
20:18:24 ℹ️ 🛑 Grafana is disabled
WARNING: Some networks were defined but are not used by any service: common-network
datanode uses an image, skipping
presto-coordinator uses an image, skipping
broker uses an image, skipping
hive-metastore uses an image, skipping
zookeeper uses an image, skipping
hive-metastore-postgresql uses an image, skipping
namenode uses an image, skipping
schema-registry uses an image, skipping
hive-server uses an image, skipping
connect uses an image, skipping
WARNING: Some networks were defined but are not used by any service: common-network
Stopping control-center  ... done
Stopping connect         ... done
Stopping schema-registry ... done
Stopping broker          ... done
Stopping zookeeper       ... done
Removing orphan container "historyserver"
Removing orphan container "nodemanager"
Removing orphan container "resourcemanager"
Removing ksqldb-cli                ... done
Removing control-center            ... done
Removing ksqldb-server             ... done
Removing connect                   ... done
Removing schema-registry           ... done
Removing broker                    ... done
Removing hive-server               ... done
Removing namenode                  ... done
Removing zookeeper                 ... done
Removing datanode                  ... done
Removing hive-metastore            ... done
Removing presto-coordinator        ... done
Removing hive-metastore-postgresql ... done
Removing network plaintext_default
Removing volume plaintext_namenode
Removing volume plaintext_datanode
WARNING: Some networks were defined but are not used by any service: common-network
Creating network "plaintext_default" with the default driver
Creating volume "plaintext_namenode" with default driver
Creating volume "plaintext_datanode" with default driver
Creating namenode                  ... done
Creating datanode                  ... done
Creating broker                    ... done
Creating presto-coordinator        ... done
Creating hive-metastore-postgresql ... done
Creating hive-metastore            ... done
Creating hive-server               ... done
Creating zookeeper                 ... done
Creating schema-registry           ... done
Creating connect                   ... done
Creating ksqldb-server             ... done
Creating control-center            ... done
Creating ksqldb-cli                ... done
20:18:52 ℹ️ 📝 To see the actual properties file, use ../../scripts/get-properties.sh <container>
20:18:52 ℹ️ ✨ If you modify a docker-compose file and want to re-create the container(s), run ../../scripts/recreate-containers.sh or use this command:
20:18:52 ℹ️ ✨ source ../../scripts/utils.sh && docker-compose -f ../../environment/plaintext/docker-compose.yml -f /Users/ajain/projects/kafka-docker-playground/connect/connect-hdfs2-sink/docker-compose.plaintext.yml --profile control-center --profile ksqldb   up -d
20:18:52 ℹ️ ⌛ Waiting up to 480 seconds for connect to start
20:21:24 ℹ️ 🚦 connect is started!
20:21:24 ℹ️ 🔧 You can use ksqlDB with CLI using:
20:21:24 ℹ️ docker exec -i ksqldb-cli ksql http://ksqldb-server:8088
20:21:24 ℹ️ 📊 JMX metrics are available locally on those ports:
20:21:24 ℹ️     - zookeeper       : 9999
20:21:24 ℹ️     - broker          : 10000
20:21:24 ℹ️     - schema-registry : 10001
20:21:24 ℹ️     - connect         : 10002
20:21:24 ℹ️     - ksqldb-server   : 10003
20:21:37 ℹ️ Creating HDFS Sink connector
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1710  100   749  100   961   2628   3371 --:--:-- --:--:-- --:--:--  6000
{
  "name": "hdfs-sink",
  "config": {
    "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
    "tasks.max": "1",
    "topics": "test_hdfs",
    "store.url": "hdfs://namenode:8020",
    "flush.size": "3",
    "hadoop.conf.dir": "/etc/hadoop/",
    "partitioner.class": "io.confluent.connect.hdfs.partitioner.FieldPartitioner",
    "partition.field.name": "f1",
    "rotate.interval.ms": "120000",
    "logs.dir": "/tmp",
    "hive.integration": "true",
    "hive.metastore.uris": "thrift://hive-metastore:9083",
    "hive.database": "testhive",
    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
    "value.converter": "io.confluent.connect.avro.AvroConverter",
    "value.converter.schema.registry.url": "http://schema-registry:8081",
    "schema.compatibility": "BACKWARD",
    "name": "hdfs-sink"
  },
  "tasks": [],
  "type": "sink"
}
20:21:38 ℹ️ Sending messages to topic test_hdfs
20:21:58 ℹ️ Listing content of /topics/test_hdfs in HDFS
Found 10 items
drwxrwxrwx   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value1
drwxrwxrwx   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value10
drwxr-xr-x   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value2
drwxr-xr-x   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value3
drwxrwxrwx   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value4
drwxrwxrwx   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value5
drwxr-xr-x   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value6
drwxrwxrwx   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value7
drwxrwxrwx   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value8
drwxrwxrwx   - appuser supergroup          0 2022-06-15 14:51 /topics/test_hdfs/f1=value9
20:22:05 ℹ️ Getting one of the avro files locally and displaying content with avro-tools
log4j:WARN No appenders could be found for logger (org.apache.hadoop.metrics2.lib.MutableMetricsFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
{"f1":"value1"}
20:22:21 ℹ️ Check data with beeline
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/hive/lib/log4j-slf4j-impl-2.6.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/hadoop-2.7.4/share/hadoop/common/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Beeline version 2.3.2 by Apache Hive
beeline> !connect jdbc:hive2://hive-server:10000/testhive
Connecting to jdbc:hive2://hive-server:10000/testhive
Enter username for jdbc:hive2://hive-server:10000/testhive: hive
Enter password for jdbc:hive2://hive-server:10000/testhive: ****
Connected to: Apache Hive (version 2.3.2)
Driver: Hive JDBC (version 2.3.2)
Transaction isolation: TRANSACTION_REPEATABLE_READ
0: jdbc:hive2://hive-server:10000/testhive> show create table test_hdfs;
+----------------------------------------------------+
|                   createtab_stmt                   |
+----------------------------------------------------+
| CREATE EXTERNAL TABLE `test_hdfs`(                 |
| )                                                  |
| PARTITIONED BY (                                   |
|   `f1` string COMMENT '')                          |
| ROW FORMAT SERDE                                   |
|   'org.apache.hadoop.hive.serde2.avro.AvroSerDe'   |
| STORED AS INPUTFORMAT                              |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'  |
| OUTPUTFORMAT                                       |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' |
| LOCATION                                           |
|   'hdfs://namenode:8020/topics/test_hdfs'          |
| TBLPROPERTIES (                                    |
|   'avro.schema.literal'='{"type":"record","name":"ConnectDefault","namespace":"io.confluent.connect.avro","fields":[]}',  |
|   'transient_lastDdlTime'='1655304711')            |
+----------------------------------------------------+
15 rows selected (1.981 seconds)
0: jdbc:hive2://hive-server:10000/testhive> select * from test_hdfs;
+---------------+
| test_hdfs.f1  |
+---------------+
| value1        |
| value2        |
| value3        |
| value4        |
| value5        |
| value6        |
| value7        |
| value8        |
| value9        |
+---------------+
9 rows selected (3.187 seconds)
0: jdbc:hive2://hive-server:10000/testhive> Closing: 0: jdbc:hive2://hive-server:10000/testhive
| value1        |
```
## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
