### PR TITLE
Added new property KERBEROS_REFRESH_TICKET for HdfsSinkConnectorConfi…

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -235,8 +235,7 @@ public class DataWriter {
 
     initializeTopicPartitionWriters(context.assignment());
   }
-
-  private void configureKerberosAuthentication(Configuration hadoopConfiguration) {
+    private void configureKerberosAuthentication(Configuration hadoopConfiguration) {
     SecurityUtil.setAuthenticationMethod(
         UserGroupInformation.AuthenticationMethod.KERBEROS,
         hadoopConfiguration
@@ -298,7 +297,9 @@ public class DataWriter {
         "Starting the Kerberos ticket renew thread with period {} ms.",
         connectorConfig.kerberosTicketRenewPeriodMs()
     );
-    ticketRenewThread.start();
+    if(connectorConfig.kerberosRefreshTicket()){
+      ticketRenewThread.start();
+    }
   }
 
   private void initializeHiveServices(Configuration hadoopConfiguration) {

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -170,6 +170,15 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
   private static final ParentValueRecommender AVRO_COMPRESSION_RECOMMENDER
       = new ParentValueRecommender(FORMAT_CLASS_CONFIG, AvroFormat.class, AVRO_SUPPORTED_CODECS);
 
+  //Kerberos renew ticket
+  public static final String KERBEROS_REFRESH_TICKET_CONFIG = "hdfs.kerberos.refresh.ticket";
+  private static final String KERBEROS_REFRESH_TICKET_DOC =
+          "Configuration indicating whether kerberos should refresh ticket or not.";
+  private static final boolean KERBEROS_REFRESH_TICKET_DEFAULT = true;
+  private static final String KERBEROS_REFRESH_TICKET_DISPLAY = "Kerberos refresh ticket";
+  private static final ConfigDef.Recommender KerberosRenewTicketDependentsRecommender =
+          new BooleanParentRecommender(
+                  KERBEROS_REFRESH_TICKET_CONFIG);
   static {
     STORAGE_CLASS_RECOMMENDER.addValidValues(
         Arrays.asList(HdfsStorage.class)
@@ -339,6 +348,18 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
           KERBEROS_TICKET_RENEW_PERIOD_MS_DISPLAY,
           hdfsAuthenticationKerberosDependentsRecommender
       );
+
+      configDef.define(
+              KERBEROS_REFRESH_TICKET_CONFIG,
+              Type.BOOLEAN,
+              KERBEROS_REFRESH_TICKET_DEFAULT,
+              Importance.LOW,
+              KERBEROS_REFRESH_TICKET_DOC,
+              group,
+              ++orderInGroup,
+              Width.SHORT,
+              KERBEROS_REFRESH_TICKET_DISPLAY
+      );
     }
     // Put the storage group(s) last ...
     ConfigDef storageConfigDef = StorageSinkConnectorConfig.newConfigDef(
@@ -503,6 +524,9 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     return getLong(KERBEROS_TICKET_RENEW_PERIOD_MS_CONFIG);
   }
 
+  public boolean kerberosRefreshTicket() {
+    return getBoolean(KERBEROS_REFRESH_TICKET_CONFIG);
+  }
   public String logsDir() {
     return getString(LOGS_DIR_CONFIG);
   }

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfigTest.java
@@ -270,6 +270,19 @@ public class HdfsSinkConnectorConfigTest extends TestWithMiniDFSCluster {
   }
 
   @Test
+  public void testKerberosRefreshTicketDefault() {
+    connectorConfig = new HdfsSinkConnectorConfig(properties);
+    assertEquals(Boolean.TRUE,
+            connectorConfig.kerberosRefreshTicket());
+  }
+  @Test
+  public void testKerberosRefreshTicket() {
+    properties.put(HdfsSinkConnectorConfig.KERBEROS_REFRESH_TICKET_CONFIG, "false");
+    connectorConfig = new HdfsSinkConnectorConfig(properties);
+    assertEquals(Boolean.FALSE,
+            connectorConfig.kerberosRefreshTicket());
+  }
+  @Test
   public void testRecommendedValues() throws Exception {
     List<Object> expectedStorageClasses = Arrays.<Object>asList(HdfsStorage.class);
 


### PR DESCRIPTION
…g that allows the possibility of never refreshing the token

## Problem
Needed to never refresh kerberos token due to kerberos stopping the pipeline each week
## Solution
Created a common solution that allows users not to use refresh of kerberos tickets at all

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
I have tested that the configuration applies correctly in the configuration test

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
Only releases a new config feature, so it should be harmless
<!-- Are you backporting or merging to master? -->
Mergin to master
<!-- If you are reverting or rolling back, is it safe? --> 
I have put this config value as true by default so it is safe