### PR TITLE
Fix ORC Logical types

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/orc/OrcRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/orc/OrcRecordWriterProvider.java
@@ -16,9 +16,9 @@
 package io.confluent.connect.hdfs.orc;
 
 import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.hdfs.schema.HiveSchemaConverterWithLogicalTypes;
 import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
-import io.confluent.connect.storage.hive.HiveSchemaConverter;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.orc.OrcFile;
 import org.apache.hadoop.hive.ql.io.orc.OrcStruct;
@@ -70,7 +70,7 @@ public class OrcRecordWriterProvider implements RecordWriterProvider<HdfsSinkCon
                 }
               };
 
-              typeInfo = HiveSchemaConverter.convert(schema);
+              typeInfo = HiveSchemaConverterWithLogicalTypes.convert(schema);
               ObjectInspector objectInspector = OrcStruct.createObjectInspector(typeInfo);
 
               log.info("Opening ORC record writer for: {}", filename);
@@ -90,7 +90,7 @@ public class OrcRecordWriterProvider implements RecordWriterProvider<HdfsSinkCon
             );
 
             Struct struct = (Struct) record.value();
-            OrcStruct row = OrcUtil.createOrcStruct(typeInfo, OrcUtil.convertStruct(struct));
+            OrcStruct row = OrcUtil.createOrcStruct(typeInfo, OrcUtil.convertStruct(typeInfo, struct));
             writer.addRow(row);
 
           } else {

--- a/src/main/java/io/confluent/connect/hdfs/orc/OrcRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/orc/OrcRecordWriterProvider.java
@@ -90,7 +90,10 @@ public class OrcRecordWriterProvider implements RecordWriterProvider<HdfsSinkCon
             );
 
             Struct struct = (Struct) record.value();
-            OrcStruct row = OrcUtil.createOrcStruct(typeInfo, OrcUtil.convertStruct(typeInfo, struct));
+            OrcStruct row = OrcUtil.createOrcStruct(
+                typeInfo,
+                OrcUtil.convertStruct(typeInfo, struct)
+            );
             writer.addRow(row);
 
           } else {

--- a/src/main/java/io/confluent/connect/hdfs/orc/OrcUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/orc/OrcUtil.java
@@ -28,12 +28,16 @@ import static org.apache.kafka.connect.data.Schema.Type.MAP;
 import static org.apache.kafka.connect.data.Schema.Type.STRING;
 import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.io.orc.OrcStruct;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.io.ShortWritable;
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector;
@@ -50,6 +54,7 @@ import org.apache.hadoop.io.MapWritable;
 import org.apache.hadoop.io.ObjectWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
@@ -142,6 +147,12 @@ public final class OrcUtil {
   }
 
   private static Object convertBytes(TypeInfo typeInfo, Struct struct, Field field) {
+
+    if (Decimal.LOGICAL_NAME.equals(field.schema().name())) {
+      BigDecimal bigDecimal = (BigDecimal) struct.get(field.name());
+      return new HiveDecimalWritable(HiveDecimal.create(bigDecimal));
+    }
+
     return new BytesWritable(struct.getBytes(field.name()));
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/orc/OrcUtil.java
+++ b/src/main/java/io/confluent/connect/hdfs/orc/OrcUtil.java
@@ -30,7 +30,6 @@ import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.BiFunction;
 import org.apache.hadoop.hive.ql.io.orc.OrcStruct;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
@@ -39,6 +38,7 @@ import org.apache.hadoop.hive.serde2.io.ShortWritable;
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.ArrayPrimitiveWritable;
 import org.apache.hadoop.io.BooleanWritable;
@@ -62,7 +62,11 @@ import java.util.List;
 
 public final class OrcUtil {
 
-  private static Map<Type, BiFunction<Struct, Field, Object>> CONVERSION_MAP = new HashMap<>();
+  private interface OrcConverter {
+    Object convert(TypeInfo typeInfo, Struct struct, Field field);
+  }
+
+  private static final Map<Type, OrcConverter> CONVERSION_MAP = new HashMap<>();
 
   static {
     CONVERSION_MAP.put(ARRAY, OrcUtil::convertArray);
@@ -87,8 +91,8 @@ public final class OrcUtil {
    * @return the struct object
    */
   @SuppressWarnings("unchecked")
-  public static OrcStruct createOrcStruct(TypeInfo typeInfo, Object... objs) {
-    SettableStructObjectInspector oi = (SettableStructObjectInspector) 
+  public static OrcStruct createOrcStruct(TypeInfo typeInfo, Object[] objs) {
+    SettableStructObjectInspector oi = (SettableStructObjectInspector)
             OrcStruct.createObjectInspector(typeInfo);
 
     List<StructField> fields = (List<StructField>) oi.getAllStructFieldRefs();
@@ -107,53 +111,57 @@ public final class OrcUtil {
    * @param struct the struct to convert
    * @return the struct as a writable array
    */
-  public static Object[] convertStruct(Struct struct) {
+  public static Object[] convertStruct(TypeInfo typeInfo, Struct struct) {
     List<Object> data = new LinkedList<>();
     for (Field field : struct.schema().fields()) {
       if (struct.get(field) == null) {
         data.add(null);
       } else {
         Schema.Type schemaType = field.schema().type();
-        data.add(CONVERSION_MAP.get(schemaType).apply(struct, field));
+        data.add(CONVERSION_MAP.get(schemaType).convert(typeInfo, struct, field));
       }
     }
 
     return data.toArray();
   }
 
-  private static Object convertStruct(Struct struct, Field field) {
-    return convertStruct(struct.getStruct(field.name()));
+  private static Object convertStruct(TypeInfo typeInfo, Struct struct, Field field) {
+    Struct fieldStruct = struct.getStruct(field.name());
+    return createOrcStruct(
+        ((StructTypeInfo)typeInfo).getStructFieldTypeInfo(field.name()),
+        convertStruct(typeInfo, fieldStruct)
+    );
   }
 
-  private static Object convertArray(Struct struct, Field field) {
+  private static Object convertArray(TypeInfo typeInfo, Struct struct, Field field) {
     return new ArrayPrimitiveWritable(struct.getArray(field.name()).toArray());
   }
 
-  private static Object convertBoolean(Struct struct, Field field) {
+  private static Object convertBoolean(TypeInfo typeInfo, Struct struct, Field field) {
     return new BooleanWritable(struct.getBoolean(field.name()));
   }
 
-  private static Object convertBytes(Struct struct, Field field) {
+  private static Object convertBytes(TypeInfo typeInfo, Struct struct, Field field) {
     return new BytesWritable(struct.getBytes(field.name()));
   }
 
-  private static Object convertFloat32(Struct struct, Field field) {
+  private static Object convertFloat32(TypeInfo typeInfo, Struct struct, Field field) {
     return new FloatWritable(struct.getFloat32(field.name()));
   }
 
-  private static Object convertFloat64(Struct struct, Field field) {
+  private static Object convertFloat64(TypeInfo typeInfo, Struct struct, Field field) {
     return new DoubleWritable(struct.getFloat64(field.name()));
   }
 
-  private static Object convertInt8(Struct struct, Field field) {
+  private static Object convertInt8(TypeInfo typeInfo, Struct struct, Field field) {
     return new ByteWritable(struct.getInt8(field.name()));
   }
 
-  private static Object convertInt16(Struct struct, Field field) {
+  private static Object convertInt16(TypeInfo typeInfo, Struct struct, Field field) {
     return new ShortWritable(struct.getInt16(field.name()));
   }
 
-  private static Object convertInt32(Struct struct, Field field) {
+  private static Object convertInt32(TypeInfo typeInfo, Struct struct, Field field) {
 
     if (Date.LOGICAL_NAME.equals(field.schema().name())) {
       java.util.Date date = (java.util.Date) struct.get(field);
@@ -162,13 +170,13 @@ public final class OrcUtil {
 
     if (Time.LOGICAL_NAME.equals(field.schema().name())) {
       java.util.Date date = (java.util.Date) struct.get(field);
-      return new TimestampWritable(new java.sql.Timestamp(date.getTime()));
+      return new IntWritable((int) date.getTime());
     }
 
     return new IntWritable(struct.getInt32(field.name()));
   }
 
-  private static Object convertInt64(Struct struct, Field field) {
+  private static Object convertInt64(TypeInfo typeInfo, Struct struct, Field field) {
 
     if (Timestamp.LOGICAL_NAME.equals(field.schema().name())) {
       java.util.Date date = (java.util.Date) struct.get(field);
@@ -178,7 +186,7 @@ public final class OrcUtil {
     return new LongWritable(struct.getInt64(field.name()));
   }
 
-  private static Object convertMap(Struct struct, Field field) {
+  private static Object convertMap(TypeInfo typeInfo, Struct struct, Field field) {
     MapWritable mapWritable = new MapWritable();
     struct.getMap(field.name()).forEach(
         (key, value) -> mapWritable.put(new ObjectWritable(key), new ObjectWritable(value))
@@ -187,7 +195,7 @@ public final class OrcUtil {
     return mapWritable;
   }
 
-  private static Object convertString(Struct struct, Field field) {
+  private static Object convertString(TypeInfo typeInfo, Struct struct, Field field) {
     return new Text(struct.getString(field.name()));
   }
 }

--- a/src/main/java/io/confluent/connect/hdfs/schema/HiveSchemaConverterWithLogicalTypes.java
+++ b/src/main/java/io/confluent/connect/hdfs/schema/HiveSchemaConverterWithLogicalTypes.java
@@ -71,6 +71,10 @@ public class HiveSchemaConverterWithLogicalTypes {
           return TypeInfoFactory.dateTypeInfo;
         case Timestamp.LOGICAL_NAME:
           return TypeInfoFactory.timestampTypeInfo;
+        // NOTE: We currently leave TIME values as INT32 (the default).
+        //       Converting to a STRING would be ok too.
+        //       Sadly, writing as INTERVAL is unsupported in the kafka-connect library.
+        //       See: org.apache.hadoop.hive.ql.io.orc.WriterImpl - INTERVAL is missing
         //case Time.LOGICAL_NAME:
         //  return TypeInfoFactory.intervalDayTimeTypeInfo;
         default:
@@ -79,7 +83,6 @@ public class HiveSchemaConverterWithLogicalTypes {
     }
 
     // HiveSchemaConverter converts primitives just fine, just not all logical-types.
-    // TODO: Verify DECIMAL conversions work as expected
     return HiveSchemaConverter.convertPrimitiveMaybeLogical(schema);
   }
 }

--- a/src/main/java/io/confluent/connect/hdfs/schema/HiveSchemaConverterWithLogicalTypes.java
+++ b/src/main/java/io/confluent/connect/hdfs/schema/HiveSchemaConverterWithLogicalTypes.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.schema;
+
+import io.confluent.connect.storage.hive.HiveSchemaConverter;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Timestamp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HiveSchemaConverterWithLogicalTypes {
+
+  public static TypeInfo convert(Schema schema) {
+    // TODO: throw an error on recursive types
+    switch (schema.type()) {
+      case STRUCT:
+        return convertStruct(schema);
+      case ARRAY:
+        return convertArray(schema);
+      case MAP:
+        return convertMap(schema);
+      default:
+        return convertPrimitive(schema);
+    }
+  }
+
+  public static TypeInfo convertStruct(Schema schema) {
+    final List<Field> fields = schema.fields();
+    final List<String> names = new ArrayList<>(fields.size());
+    final List<TypeInfo> types = new ArrayList<>(fields.size());
+    for (Field field : fields) {
+      names.add(field.name());
+      types.add(convert(field.schema()));
+    }
+    return TypeInfoFactory.getStructTypeInfo(names, types);
+  }
+
+  public static TypeInfo convertArray(Schema schema) {
+    return TypeInfoFactory.getListTypeInfo(convert(schema.valueSchema()));
+  }
+
+  public static TypeInfo convertMap(Schema schema) {
+    return TypeInfoFactory.getMapTypeInfo(
+        convert(schema.keySchema()),
+        convert(schema.valueSchema())
+    );
+  }
+
+  public static TypeInfo convertPrimitive(Schema schema) {
+    if (schema.name() != null) {
+      switch (schema.name()) {
+        case Date.LOGICAL_NAME:
+          return TypeInfoFactory.dateTypeInfo;
+        case Timestamp.LOGICAL_NAME:
+          return TypeInfoFactory.timestampTypeInfo;
+        //case Time.LOGICAL_NAME:
+        //  return TypeInfoFactory.intervalDayTimeTypeInfo;
+        default:
+          break;
+      }
+    }
+
+    // HiveSchemaConverter converts primitives just fine, just not all logical-types.
+    // TODO: Verify DECIMAL conversions work as expected
+    return HiveSchemaConverter.convertPrimitiveMaybeLogical(schema);
+  }
+}

--- a/src/test/java/io/confluent/connect/hdfs/orc/DataWriterOrcTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/orc/DataWriterOrcTest.java
@@ -19,7 +19,7 @@ package io.confluent.connect.hdfs.orc;
 import io.confluent.connect.hdfs.DataWriter;
 import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
-import io.confluent.connect.storage.hive.HiveSchemaConverter;
+import io.confluent.connect.hdfs.schema.HiveSchemaConverterWithLogicalTypes;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -80,7 +80,7 @@ public class DataWriterOrcTest extends TestWithMiniDFSCluster {
         expectedRecords.get(startIndex++).value(),
         expectedSchema);
 
-      TypeInfo typeInfo = HiveSchemaConverter.convert(expectedSchema);
+      TypeInfo typeInfo = HiveSchemaConverterWithLogicalTypes.convert(expectedSchema);
 
       ArrayList<Object> objs = new ArrayList<>();
       for (Field field : expectedSchema.fields()) {


### PR DESCRIPTION
## Problem

Many Logical types don't work when writing ORC.
And when a hierarchal Record comes through, logical types are ignored entirely (convertPrimitiveMaybeLogical() is never called during recursive traversal), including DECIMAL.
Bug where hierarchal (not flattened) Kafka Connect records aren't converted to OrcStructs correctly.

## Solution

Code changes to identify and serialize Kafka Connect Logical Types correctly, for: Date, Time and Timestamp and Decimal.
By default, parse all Logical types.

This PR should _not_ be merged directly, and the following things need to be done:

1. Consider keeping the original DECIMAL Precision value. Currently Scale is propagated, but Precision is discarded, and a hard-coded value of 38 is used instead.
2. Unit tests were not updated/fixed
3. The  HiveSchemaConverter is deep within a shared library, so instead of fixing that class, and new class was created: HiveSchemaConverterWithLogicalTypes. The fixes should be made to the original class, and the new class should not be used.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
