### PR TITLE
trigger rotation on offset flush

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -356,7 +356,7 @@ public class DataWriter {
     }
   }
 
-  public void write(Collection<SinkRecord> records) {
+  public synchronized void write(Collection<SinkRecord> records) {
     for (SinkRecord record : records) {
       String topic = record.topic();
       int partition = record.kafkaPartition();

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -134,6 +135,9 @@ public class HdfsSinkTask extends SinkTask {
     } catch (ConnectException e) {
       throw new ConnectException(e);
     }
+  }
+  public void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+    hdfsWriter.write(Collections.emptyList());
   }
 
   @Override


### PR DESCRIPTION
## Problem

The rotation is only triggered when a record comes in, so if there are few new records, a lot of data will remain in tmp

#329 


## Solution


Implementing the flush() of HdfsSinkTask, when `offset.flush` trigger, check the rotation conditions. If the tmp file is older than `rotate.schedule.interval.ms`, then rotate.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
