### PR TITLE
CC-18964  CCMSG-2421 CCMSG-2420  Update Ivy, commons-net, json-smart, mina-core and xmlbuilder 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <kafka.connect.storage.common.version>11.0.21</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons-net.version>3.9.0</commons-net.version>
-        <ivy.version>2.4.0</json-smart.version>
+        <ivy.version>2.5.1</json-smart.version>
         <json-smart.version>2.4.10</json-smart.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
                 <artifactId>mina-core</artifactId>
                 <version>2.0.23</version>
             </dependency>
+            <dependency>
+                <groupId>com.jamesmurty.utils</groupId>
+                <artifactId>java-xmlbuilder</artifactId>
+                <version>1.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <kafka.connect.storage.common.version>11.0.21</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons-net.version>3.9.0</commons-net.version>
+        <ivy.version>2.4.0</json-smart.version>
         <json-smart.version>2.4.10</json-smart.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
@@ -101,7 +102,12 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>${commons-net.version}</version>
+                <version>${json-smart.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ivy</groupId>
+                <artifactId>ivy</artifactId>
+                <version>${ivy.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -308,11 +308,17 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
-        <!-- pin the dependency to fix CVE : CCMSG-2266-->
+        <!-- pin the dependency to fix CVE -->
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
             <version>6.5.0</version>
+        </dependency>
+        <!-- pin the dependency to fix CVE -->
+        <dependency>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+            <version>1.5.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.16</version>
+        <version>11.0.22</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -52,12 +52,11 @@
     </scm>
 
     <properties>
-        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>11.0.16</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>11.0.22</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
@@ -72,7 +71,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
-        <jettison.version>0.13.0</jettison.version>
-        <woodstox-core.version>0.13.0</woodstox-core.version>
+        <jettison.version>1.5.3</jettison.version>
+        <woodstox-core.version>6.5.0</woodstox-core.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,12 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+        <!-- pin the dependency to fix CVE : CCMSG-2266-->
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.5.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
+        <jettison.version>0.13.0</jettison.version>
+        <woodstox-core.version>0.13.0</woodstox-core.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>
@@ -73,6 +75,24 @@
             <url>${confluent.maven.repo}</url>
         </repository>
     </repositories>
+
+
+    <dependencyManagement>
+        <dependencies>
+        <!-- pin the dependency to fix CVE -->
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>${woodstox-core.version}</version>
+            </dependency>
+            <!-- pin the dependency to fix CVE -->
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>${jettison.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -307,18 +327,6 @@
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
             <scope>test</scope>
-        </dependency>
-        <!-- pin the dependency to fix CVE -->
-        <dependency>
-            <groupId>com.fasterxml.woodstox</groupId>
-            <artifactId>woodstox-core</artifactId>
-            <version>6.5.0</version>
-        </dependency>
-        <!-- pin the dependency to fix CVE -->
-        <dependency>
-            <groupId>org.codehaus.jettison</groupId>
-            <artifactId>jettison</artifactId>
-            <version>1.5.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <kafka.connect.storage.common.version>11.0.21</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
+        <commons-net.version>3.9.0</commons-net.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
         <jettison.version>1.5.4</jettison.version>
@@ -91,6 +92,12 @@
                 <artifactId>jettison</artifactId>
                 <version>${jettison.version}</version>
             </dependency>
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>${commons-net.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
         <jettison.version>1.5.4</jettison.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <woodstox-core.version>6.5.0</woodstox-core.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <kafka.connect.storage.common.version>11.0.21</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons-net.version>3.9.0</commons-net.version>
+        <json-smart.version>2.4.10</json-smart.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
         <jettison.version>1.5.4</jettison.version>
@@ -97,7 +98,11 @@
                 <artifactId>commons-net</artifactId>
                 <version>${commons-net.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${commons-net.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
                 <artifactId>ivy</artifactId>
                 <version>${ivy.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.mina</groupId>
+                <artifactId>mina-core</artifactId>
+                <version>2.0.23</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
                 <artifactId>xercesImpl</artifactId>
                 <version>2.12.2</version>
             </dependency>
+            <!-- pin slider-core to avoid outdated httpclient -->
+            <dependency>
+                <groupId>org.apache.slider</groupId>
+                <artifactId>slider-core</artifactId>
+                <version>0.92.0-incubating</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <kafka.connect.storage.common.version>11.0.21</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons-net.version>3.9.0</commons-net.version>
-        <ivy.version>2.4.0</ivy.version>
+        <ivy.version>2.5.1</ivy.version>
         <json-smart.version>2.4.10</json-smart.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <kafka.connect.storage.common.version>11.0.21</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons-net.version>3.9.0</commons-net.version>
-        <ivy.version>2.5.1</json-smart.version>
+        <ivy.version>2.4.0</ivy.version>
         <json-smart.version>2.4.10</json-smart.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
         <jettison.version>1.5.4</jettison.version>
-        <snakeyaml.version>2.0</snakeyaml.version>cccccbeffenflgflugbfchdenuijernnlulidrfvgnkg
+        <snakeyaml.version>2.0</snakeyaml.version>
 
         <woodstox-core.version>6.5.0</woodstox-core.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,11 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
-        <jettison.version>1.5.3</jettison.version>
+        <jettison.version>1.5.4</jettison.version>
         <woodstox-core.version>6.5.0</woodstox-core.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
+        <!-- this should be probably removed, the above mentioned PR was in 2021  -->
         <dependency.check.version>6.1.6</dependency.check.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
         <log4j2-api.version>2.17.1</log4j2-api.version>
         <jettison.version>1.5.4</jettison.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-
         <woodstox-core.version>6.5.0</woodstox-core.version>
     </properties>
 
@@ -93,7 +92,6 @@
                 <artifactId>jettison</artifactId>
                 <version>${jettison.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>commons-net</groupId>
                 <artifactId>commons-net</artifactId>
@@ -123,6 +121,12 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+          <!-- Pin xercesImpl to resolve CVE-2022-2343   -->
+            <dependency>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+                <version>2.12.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.22</version>
+        <version>11.0.21</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -56,7 +56,7 @@
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>11.0.22</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>11.0.21</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
         <jettison.version>1.5.4</jettison.version>
+        <snakeyaml.version>2.0</snakeyaml.version>cccccbeffenflgflugbfchdenuijernnlulidrfvgnkg
+
         <woodstox-core.version>6.5.0</woodstox-core.version>
     </properties>
 
@@ -116,6 +118,11 @@
                 <groupId>com.jamesmurty.utils</groupId>
                 <artifactId>java-xmlbuilder</artifactId>
                 <version>1.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,7 @@
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
         <jettison.version>1.5.4</jettison.version>
-        <snakeyaml.version>2.0</snakeyaml.version>
         <woodstox-core.version>6.5.0</woodstox-core.version>
-        <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
-            See https://github.com/confluentinc/common/pull/332 for details -->
-        <!-- this should be probably removed, the above mentioned PR was in 2021  -->
-        <dependency.check.version>6.1.6</dependency.check.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Problem
woodstox-core:5.3.0 and jettison:1.1 are vulnerable. 

## Solution
Pin woodstox-core:6.5.0 and jettison:1.5.3 to fix the CVE

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
