### PR TITLE
bump parent to 11.0.21 to fix jackson-databind-cve

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
   ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   ~ WARRANTIES OF ANY KIND, either express or implied.  See the License for the
   ~ specific language governing permissions and limitations under the License.
+  ~ dummy comment
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
     </scm>
 
     <properties>
-        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
@@ -70,7 +69,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.16</version>
+        <version>11.0.20</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -57,7 +57,7 @@
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>11.0.16</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>11.0.20</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     </scm>
 
     <properties>
-        <!-- <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo> -->
+        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
@@ -70,7 +70,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>https://packages.confluent.io/maven/</url>
+            <url>${confluent.maven.repo}</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
   ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   ~ WARRANTIES OF ANY KIND, either express or implied.  See the License for the
   ~ specific language governing permissions and limitations under the License.
-  ~ dummy comment
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.20</version>
+        <version>11.0.21</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -57,7 +57,7 @@
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>11.0.20</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>11.0.21</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <libthrift.version>0.13.0</libthrift.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     </scm>
 
     <properties>
-        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
+        <!-- <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo> -->
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
@@ -70,7 +70,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-18965

## Solution
Update the parent version to 11.0.21
https://github.com/confluentinc/kafka-connect-storage-common/pull/308

Use url directly
https://github.com/confluentinc/kafka-connect-storage-cloud/pull/618


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
