### PR TITLE
explicit import of slider-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- explicitly add slider-core as the dependencyManagement does not seem to override
+        the import of org.apache.hive:hive-llap-server -->
+        <dependency>
+            <groupId>org.apache.slider</groupId>
+            <artifactId>slider-core</artifactId>
+            <version>0.92.0-incubating</version>
+        </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>


### PR DESCRIPTION
## Problem
The previous solution for CVE-2020-13956 seems to be insufficient. Trying an explicit dependency import. 

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
