### PR TITLE
Solved the problem of files getting stuck in the temporary folder due…

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -464,6 +464,14 @@ public class DataWriter {
     }
   }
 
+  public void checkWritersForNecessityOfRotation() {
+    for (TopicPartitionWriter topicPartitionWriter : topicPartitionWriters.values()) {
+      if (topicPartitionWriter.shouldRotateAndMaybeUpdateTimers()) {
+        topicPartitionWriter.write();
+      }
+    }
+  }
+
   public void close() {
     // Close any writers we have. We may get assigned the same partitions and end up duplicating
     // some effort since we'll have to reprocess those messages. It may be possible to hold on to

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -143,6 +143,10 @@ public class HdfsSinkTask extends SinkTask {
     // Although the connector manages offsets via files in HDFS, we still want to have Connect
     // commit the consumer offsets for records this task has consumed from its topic partitions and
     // committed to HDFS.
+
+    // Check writers for should rotate by rotation interval
+    hdfsWriter.checkWritersForNecessityOfRotation();
+
     Map<TopicPartition, OffsetAndMetadata> result = new HashMap<>();
     for (Map.Entry<TopicPartition, Long> entry : hdfsWriter.getCommittedOffsets().entrySet()) {
       log.debug(

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -246,7 +246,7 @@ public class TopicPartitionWriter {
     }
 
     // Initialize rotation timers
-    updateRotationTimers(null);
+    updateRotationTimers();
   }
 
   @SuppressWarnings("fallthrough")
@@ -290,12 +290,9 @@ public class TopicPartitionWriter {
     return true;
   }
 
-  private void updateRotationTimers(SinkRecord currentRecord) {
+  private void updateRotationTimers() {
     long now = time.milliseconds();
-    // Wallclock-based partitioners should be independent of the record argument.
-    lastRotate = isWallclockBased
-                 ? (Long) now
-                 : currentRecord != null ? timestampExtractor.extract(currentRecord) : null;
+    lastRotate = time.milliseconds();
     if (log.isDebugEnabled() && rotateIntervalMs > 0) {
       log.debug(
           "Update last rotation timer. Next rotation for {} will be in {}ms",
@@ -322,7 +319,6 @@ public class TopicPartitionWriter {
   @SuppressWarnings("fallthrough")
   public void write() {
     long now = time.milliseconds();
-    SinkRecord currentRecord = null;
     if (failureTime > 0 && now - failureTime < timeoutMs) {
       return;
     }
@@ -331,7 +327,7 @@ public class TopicPartitionWriter {
       if (!success) {
         return;
       }
-      updateRotationTimers(null);
+      updateRotationTimers();
     }
     while (!buffer.isEmpty()) {
       try {
@@ -358,7 +354,6 @@ public class TopicPartitionWriter {
               }
             }
             SinkRecord record = buffer.peek();
-            currentRecord = record;
             Schema valueSchema = record.valueSchema();
             if ((recordCounter <= 0 && currentSchema == null && valueSchema != null)
                 || compatibility.shouldChangeSchema(record, null, currentSchema)) {
@@ -373,7 +368,7 @@ public class TopicPartitionWriter {
                 break;
               }
             } else {
-              if (shouldRotateAndMaybeUpdateTimers(currentRecord, now)) {
+              if (shouldRotateAndMaybeUpdateTimers(now)) {
                 log.info(
                     "Starting commit and rotation for topic partition {} with start offsets {} "
                         + "and end offsets {}",
@@ -391,7 +386,7 @@ public class TopicPartitionWriter {
               }
             }
           case SHOULD_ROTATE:
-            updateRotationTimers(currentRecord);
+            updateRotationTimers();
             closeTempFile();
             nextState();
           case TEMP_FILE_CLOSED:
@@ -424,7 +419,7 @@ public class TopicPartitionWriter {
           case WRITE_PARTITION_PAUSED:
             // committing files after waiting for rotateIntervalMs time but less than flush.size
             // records available
-            if (recordCounter == 0 || !shouldRotateAndMaybeUpdateTimers(currentRecord, now)) {
+            if (recordCounter == 0 || !shouldRotateAndMaybeUpdateTimers(now)) {
               break;
             } 
             
@@ -434,7 +429,7 @@ public class TopicPartitionWriter {
             );
             nextState();
           case SHOULD_ROTATE:
-            updateRotationTimers(currentRecord);
+            updateRotationTimers();
             closeTempFile();
             nextState();
           case TEMP_FILE_CLOSED:
@@ -559,19 +554,14 @@ public class TopicPartitionWriter {
     this.state = state;
   }
 
-  private boolean shouldRotateAndMaybeUpdateTimers(SinkRecord currentRecord, long now) {
-    Long currentTimestamp = null;
-    if (isWallclockBased) {
-      currentTimestamp = now;
-    } else if (currentRecord != null) {
-      currentTimestamp = timestampExtractor.extract(currentRecord);
-      lastRotate = lastRotate == null ? currentTimestamp : lastRotate;
-    }
+  public boolean shouldRotateAndMaybeUpdateTimers() {
+    return shouldRotateAndMaybeUpdateTimers(time.milliseconds());
+  }
 
+  private boolean shouldRotateAndMaybeUpdateTimers(long now) {
     boolean periodicRotation = rotateIntervalMs > 0
-        && currentTimestamp != null
         && lastRotate != null
-        && currentTimestamp - lastRotate >= rotateIntervalMs;
+        && now - lastRotate >= rotateIntervalMs;
     boolean scheduledRotation = rotateScheduleIntervalMs > 0 && now >= nextScheduledRotate;
     boolean messageSizeRotation = recordCounter >= flushSize;
 
@@ -580,7 +570,7 @@ public class TopicPartitionWriter {
             + "'{}', timestamp: '{}')? {}",
         rotateIntervalMs,
         lastRotate,
-        currentTimestamp,
+        now,
         periodicRotation
     );
 


### PR DESCRIPTION
… to the lack of new messages in the topic despite the set property rotate.interval.ms. Property flush.size now also works correctly.

## Problem
Occasionally I faced a problem when files were stuck in `+tmp` folder despite the set property `rotate.interval.ms`. This situation was observed when new messages stopped falling into the topic. The parameter
`rotate.interval.ms` did not work, because there was no trigger that could cause a check on it.
Also, while working on this problem, I was able to fix the rotation mechanism and accordingly the `flush.size` parameter. As written in the documentation: rotation can be controlled by the file collection time (`rotate.interval.ms`) and/or by the number of messages in the file (`flush.size`). In fact, rotation by time did not work by the file collection time, but by the time of the field for partitioning. And if one Kafka partition contained messages whose difference in values in the field by which partitioning was done was greater than the value of `rotate.interval.ms`, then rotation occurred and premature flush of the file from the temporary folder to the permanent one. This led to a large number of small files and the inability to correctly control writing using the `flush.size` parameter. Now this problem is not observed.


## Solution
I added a check for this parameter in `HdfsSinkTask.preCommit()`. Also, I fixed the logic of rotation in `TopicPartitionWriter.shouldRotateAndMaybeUpdateTimers()` method.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests
