### PR TITLE
CVE fixes: jackson-core, snappy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.1.4</version>
+        <version>11.2.3</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -65,6 +65,7 @@
         <log4j2-api.version>2.17.1</log4j2-api.version>
         <jettison.version>1.5.4</jettison.version>
         <snakeyaml.version>2.0</snakeyaml.version>
+        <snappy.java.version>1.1.10.3</snappy.java.version>
         <woodstox-core.version>6.5.0</woodstox-core.version>
     </properties>
 
@@ -133,6 +134,12 @@
                 <groupId>org.apache.slider</groupId>
                 <artifactId>slider-core</artifactId>
                 <version>0.92.0-incubating</version>
+            </dependency>
+            <!-- pin slider-core to avoid outdated httpclient -->
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy.java.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
                 <artifactId>slider-core</artifactId>
                 <version>0.92.0-incubating</version>
             </dependency>
-            <!-- pin slider-core to avoid outdated httpclient -->
+            <!-- pin dependency to fix cve -->
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>


### PR DESCRIPTION
## Problem
CVE fixes for
https://confluentinc.atlassian.net/browse/CC-20975
https://confluentinc.atlassian.net/browse/CC-20976  
https://confluentinc.atlassian.net/browse/CC-20328

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

##### Manual Testing in Docker Playground 
HDFS2 Sink
```
vbalani@Vikass-MacBook-Pro connect-hdfs2-sink % playground run -f hdfs2-sink.sh --connector-zip /Users/vbalani/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-10.2.3-SNAPSHOT.zip
09:59:07 ℹ️ 🚀 Running example with flags
09:59:07 ℹ️ ⛳ Flags used are  --connector-zip=/Users/vbalani/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-10.2.3-SNAPSHOT.zip
09:59:08 ℹ️ 💀 Kill all docker containers
09:59:14 ℹ️ ####################################################
09:59:14 ℹ️ 🚀 Executing hdfs2-sink.sh in dir .
09:59:14 ℹ️ ####################################################
09:59:14 ℹ️ 💫 Using default CP version 7.5.0
09:59:14 ℹ️ 🎓 Use --tag option to specify different version, see https://kafka-docker-playground.io/#/how-to-use?id=🎯-for-confluent-platform-cp
09:59:14 ℹ️ 🎯🤐 CONNECTOR_ZIP (--connector-zip option) is set with /Users/vbalani/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-10.2.3-SNAPSHOT.zip
09:59:15 ℹ️ 🧰 Checking if Docker image confluentinc/cp-server-connect-base:7.5.0 contains additional tools
09:59:15 ℹ️ 🧰 it can take a while if image is downloaded for the first time
09:59:17 ℹ️ 🎱 Installing connector from zip confluentinc-kafka-connect-hdfs-10.2.3-SNAPSHOT.zip
Running in a "--no-prompt" mode
Implicit acceptance of the license below:
Confluent Community License
http://www.confluent.io/confluent-community-license
Installing a component Kafka Connect HDFS 10.2.3-SNAPSHOT, provided by Confluent, Inc. from the local file: /tmp/confluentinc-kafka-connect-hdfs-10.2.3-SNAPSHOT.zip into directory: /usr/share/confluent-hub-components
Adding installation directory to plugin path in the following files:
  /etc/kafka/connect-distributed.properties
  /etc/kafka/connect-standalone.properties
  /etc/schema-registry/connect-avro-distributed.properties
  /etc/schema-registry/connect-avro-standalone.properties

Completed
10:15:17 ℹ️ 🛑 control-center is disabled
10:15:17 ℹ️ 🛑 ksqldb is disabled
10:15:17 ℹ️ 🛑 Grafana is disabled
10:15:17 ℹ️ 🛑 kcat is disabled
10:15:17 ℹ️ 🛑 conduktor is disabled
[+] Running 3/3
 ⠿ Volume plaintext_datanode  Removed                                                                                                                                                                                                    0.0s
 ⠿ Volume plaintext_namenode  Removed                                                                                                                                                                                                    0.1s
 ⠿ Network plaintext_default  Removed                                                                                                                                                                                                    0.1s
[+] Running 13/13
 ⠿ Network plaintext_default            Created                                                                                                                                                                                          0.1s
 ⠿ Volume "plaintext_datanode"          Created                                                                                                                                                                                          0.0s
 ⠿ Volume "plaintext_namenode"          Created                                                                                                                                                                                          0.0s
 ⠿ Container namenode                   Started                                                                                                                                                                                          3.4s
 ⠿ Container datanode                   Started                                                                                                                                                                                          3.4s
 ⠿ Container hive-server                Started                                                                                                                                                                                          2.9s
 ⠿ Container hive-metastore-postgresql  Started                                                                                                                                                                                          3.1s
 ⠿ Container presto-coordinator         Started                                                                                                                                                                                          3.2s
 ⠿ Container zookeeper                  Started                                                                                                                                                                                          2.9s
 ⠿ Container hive-metastore             Started                                                                                                                                                                                          3.1s
 ⠿ Container broker                     Started                                                                                                                                                                                          3.5s
 ⠿ Container schema-registry            Started                                                                                                                                                                                          4.3s
 ⠿ Container connect                    Started                                                                                                                                                                                          5.2s
10:15:25 ℹ️ 📝 To see the actual properties file, use cli command playground get-properties -c <container>
10:15:25 ℹ️ ✨ If you modify a docker-compose file and want to re-create the container(s), run cli command playground container recreate
10:15:25 ℹ️ ⌛ Waiting up to 480 seconds for connect to start
10:18:22 ℹ️ 🚦 connect is started!
10:18:23 ℹ️ 📊 JMX metrics are available locally on those ports:
10:18:23 ℹ️     - zookeeper       : 9999
10:18:23 ℹ️     - broker          : 10000
10:18:23 ℹ️     - schema-registry : 10001
10:18:23 ℹ️     - connect         : 10002
10:18:38 ℹ️ Creating HDFS Sink connector
10:18:45 ℹ️ 🛠️ Creating connector hdfs-sink
10:18:46 ℹ️ ✅ Connector hdfs-sink was successfully created
10:18:46 ℹ️ 💈 Configuration is
{
  "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
  "flush.size": "3",
  "hadoop.conf.dir": "/etc/hadoop/",
  "hive.database": "testhive",
  "hive.integration": "true",
  "hive.metastore.uris": "thrift://hive-metastore:9083",
  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
  "logs.dir": "/tmp",
  "partitioner.class": "io.confluent.connect.storage.partitioner.DefaultPartitioner",
  "rotate.interval.ms": "120000",
  "schema.compatibility": "BACKWARD",
  "store.url": "hdfs://namenode:8020",
  "tasks.max": "1",
  "topics": "test_hdfs",
  "value.converter": "io.confluent.connect.avro.AvroConverter",
  "value.converter.schema.registry.url": "http://schema-registry:8081"
}
10:18:46 ℹ️ 🥁 Waiting a few seconds to get new status
10:18:58 ℹ️ 🧩 Displaying connector status for hdfs-sink
Name                           Status       Tasks                                                        Stack Trace
-----------------------------------------------------------------------------------------------------------------------------
hdfs-sink                      ✅ RUNNING  🤔 N/A                       -
-------------------------------------------------------------------------------------------------------------
10:18:59 ℹ️ Sending messages to topic test_hdfs
10:19:04 ℹ️ 🔮 schema was identified as avro
10:19:04 ℹ️ ✨ generating data...
10:19:04 ℹ️ ☢️ --forced-value is set
10:19:05 ℹ️ ✨ 10 records were generated based on --forced-value  (only showing first 10), took: 0min 6sec
{"f1":"value1"}
{"f1":"value2"}
{"f1":"value3"}
{"f1":"value4"}
{"f1":"value5"}
{"f1":"value6"}
{"f1":"value7"}
{"f1":"value8"}
{"f1":"value9"}
{"f1":"value10"}
10:19:23 ℹ️ 💯 Get number of records in topic test_hdfs
0
10:19:23 ℹ️ 📤 producing 10 records to topic test_hdfs
[2023-09-25 04:49:26,867] WARN MessageReader is deprecated. Please use org.apache.kafka.tools.api.RecordReader instead (kafka.tools.ConsoleProducer$)
10:19:29 ℹ️ 📤 produced 10 records to topic test_hdfs, took: 0min 6sec
10:19:32 ℹ️ 💯 Get number of records in topic test_hdfs
10
10:19:53 ℹ️ Listing content of /topics/test_hdfs/partition=0 in HDFS
Found 3 items
-rw-r--r--   3 appuser supergroup        213 2023-09-25 04:49 /topics/test_hdfs/partition=0/test_hdfs+0+0000000000+0000000002.avro
-rw-r--r--   3 appuser supergroup        213 2023-09-25 04:49 /topics/test_hdfs/partition=0/test_hdfs+0+0000000003+0000000005.avro
-rw-r--r--   3 appuser supergroup        213 2023-09-25 04:49 /topics/test_hdfs/partition=0/test_hdfs+0+0000000006+0000000008.avro
10:20:02 ℹ️ Getting one of the avro files locally and displaying content with avro-tools
23/09/25 04:50:24 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
{"f1":"value1"}
{"f1":"value2"}
{"f1":"value3"}
10:20:28 ℹ️ Check data with beeline
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/hive/lib/log4j-slf4j-impl-2.6.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/hadoop-2.7.4/share/hadoop/common/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Beeline version 2.3.2 by Apache Hive
beeline> !connect jdbc:hive2://hive-server:10000/testhive
Connecting to jdbc:hive2://hive-server:10000/testhive
Enter username for jdbc:hive2://hive-server:10000/testhive: hive
Enter password for jdbc:hive2://hive-server:10000/testhive: ****
Connected to: Apache Hive (version 2.3.2)
Driver: Hive JDBC (version 2.3.2)
Transaction isolation: TRANSACTION_REPEATABLE_READ
0: jdbc:hive2://hive-server:10000/testhive> show create table test_hdfs;
+----------------------------------------------------+
|                   createtab_stmt                   |
+----------------------------------------------------+
| CREATE EXTERNAL TABLE `test_hdfs`(                 |
|   `f1` string COMMENT '')                          |
| PARTITIONED BY (                                   |
|   `partition` string COMMENT '')                   |
| ROW FORMAT SERDE                                   |
|   'org.apache.hadoop.hive.serde2.avro.AvroSerDe'   |
| STORED AS INPUTFORMAT                              |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'  |
| OUTPUTFORMAT                                       |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' |
| LOCATION                                           |
|   'hdfs://namenode:8020/topics/test_hdfs'          |
| TBLPROPERTIES (                                    |
|   'avro.schema.literal'='{"type":"record","name":"ConnectDefault","namespace":"io.confluent.connect.avro","fields":[{"name":"f1","type":"string"}]}',  |
|   'transient_lastDdlTime'='1695617371')            |
+----------------------------------------------------+
15 rows selected (1.709 seconds)
0: jdbc:hive2://hive-server:10000/testhive> select * from test_hdfs;
+---------------+----------------------+
| test_hdfs.f1  | test_hdfs.partition  |
+---------------+----------------------+
| value1        | 0                    |
| value2        | 0                    |
| value3        | 0                    |
| value4        | 0                    |
| value5        | 0                    |
| value6        | 0                    |
| value7        | 0                    |
| value8        | 0                    |
| value9        | 0                    |
+---------------+----------------------+
9 rows selected (2.548 seconds)
0: jdbc:hive2://hive-server:10000/testhive> Closing: 0: jdbc:hive2://hive-server:10000/testhive
| value1        | 0                    |
10:20:40 ℹ️ ####################################################
10:20:40 ℹ️ ✅ RESULT: SUCCESS for hdfs2-sink.sh (took: 21min 26sec - )
10:20:40 ℹ️ ####################################################

10:20:44 ℹ️ ✨ --connector flag was not provided, applying command to all connectors
10:20:45 ℹ️ 🧩 Displaying connector status for hdfs-sink
Name                           Status       Tasks                                                        Stack Trace
-----------------------------------------------------------------------------------------------------------------------------
hdfs-sink                      ✅ RUNNING  0:🟢 RUNNING[connect]        -
-------------------------------------------------------------------------------------------------------------
10:20:49 ℹ️ 🗯️ Version currently used for confluentinc-kafka-connect-hdfs is not latest
10:20:49 ℹ️ Current
"🔢 v10.2.3-SNAPSHOT - 📅 release date: 2023-09-20"
10:20:49 ℹ️ Latest on Hub
"🔢 v10.2.2 - 📅 release date: 2023-06-06"
10:20:50 ℹ️ 🌐 documentation is available at:
https://docs.confluent.io/current/connect/kafka-connect-hdfs/index.html
```

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
