### PR TITLE
Multiple keytab kerberos issue

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -274,7 +274,7 @@ public class DataWriter {
           hostname
       );
       UserGroupInformation.loginUserFromKeytab(principal, connectorConfig.connectHdfsKeytab());
-      final UserGroupInformation ugi = UserGroupInformation.getLoginUser();
+      final UserGroupInformation ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, connectorConfig.connectHdfsKeytab())
       log.info("Login as: " + ugi.getUserName());
 
       isRunning = true;

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -274,7 +274,7 @@ public class DataWriter {
           hostname
       );
       UserGroupInformation.loginUserFromKeytab(principal, connectorConfig.connectHdfsKeytab());
-      final UserGroupInformation ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, connectorConfig.connectHdfsKeytab())
+      final UserGroupInformation ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, connectorConfig.connectHdfsKeytab());
       log.info("Login as: " + ugi.getUserName());
 
       isRunning = true;


### PR DESCRIPTION
## Problem
If multiple key tabs are distributed on the connect server, authentication errors may occur.

```
      UserGroupInformation.loginUserFromKeytab(principal, connectorConfig.connectHdfsKeytab()); // problem point
      final UserGroupInformation ugi = UserGroupInformation.getLoginUser();  // problem point
      log.info("Login as: " + ugi.getUserName());

      isRunning = true;
      ticketRenewThread = new Thread(() -> renewKerberosTicket(ugi));
```
example) A connector uses the test user keytab (write path: /hdfs/user/test), and B connector uses the test2 user keytab (write path: /hdfs/user/test2).
If both connectors are restarted due to certain circumstances, different key tab information can be imported with thread-based behavior.
If the B connector calls loginUserFromKeytab('[test2@EXAMPLE.COM](mailto:test2@EXAMPLE.COM)' , '/../test2.keytab') when the A connector calls getLoginUser(), A login as test2 user. So you can face the error as below.
Caused by: org.apache.ranger.authorization.hadoop.exceptions.RangerAccessControlException: Permission denied: user=test2, access=EXECUTE, inode="/hdfs/user/test"

## Solution
```      
final UserGroupInformation ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, connectorConfig.connectHdfsKeytab());
```
When receiving an ugi instance, it was changed to authenticate with a keytab and receive it.
Change to use loginUserFromKeytabAndReturnUGI() func.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ X ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ X ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ X ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
