### PR TITLE
RCCA-16236: AVRO buffer loss fix on IOException 

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -433,7 +433,6 @@ public class TopicPartitionWriter {
           log.error("Encountered AVRO IO exception, resetting this topic partition {} "
                   + "to offset {}", tp, offset);
           resetAndSetRecovery();
-          return;
         }
         break;
       }
@@ -475,6 +474,11 @@ public class TopicPartitionWriter {
         log.error("Exception on topic partition {}: ", tp, e);
         failureTime = time.milliseconds();
         setRetryTimeout(timeoutMs);
+        if (e instanceof AvroIOException) {
+          log.error("Encountered AVRO IO exception, resetting this topic partition {} "
+                  + "to offset {}", tp, offset);
+          resetAndSetRecovery();
+        }
         return;
       }
 

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -259,7 +258,7 @@ public class TopicPartitionWriter {
   }
 
   private void safeDeleteTempFiles() {
-    for (String encodedPartition : tempFiles.values()) {
+    for (String encodedPartition : tempFiles.keySet()) {
       try {
         deleteTempFile(encodedPartition);
       } catch (ConnectException e) {

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.hdfs;
 
+import io.confluent.connect.hdfs.avro.AvroIOException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
@@ -246,6 +247,17 @@ public class TopicPartitionWriter {
     updateRotationTimers(null);
   }
 
+  public void resetBuffers() {
+    buffer.clear();
+    writers.clear();
+    tempFiles.clear();
+    appended.clear();
+    startOffsets.clear();
+    endOffsets.clear();
+    recordCounter = 0;
+    currentSchema = null;
+  }
+
   @SuppressWarnings("fallthrough")
   public boolean recover() {
     try {
@@ -279,8 +291,9 @@ public class TopicPartitionWriter {
               tp
           );
       }
-    } catch (ConnectException e) {
+    } catch (AvroIOException | ConnectException e) {
       log.error("Recovery failed at state {}", state, e);
+      failureTime = time.milliseconds();
       setRetryTimeout(timeoutMs);
       return false;
     }
@@ -314,6 +327,13 @@ public class TopicPartitionWriter {
         );
       }
     }
+  }
+
+  public void resetAndSetRecovery() {
+    context.offset(tp, offset);
+    resetBuffers();
+    state = State.RECOVERY_STARTED;
+    recovered = false;
   }
 
   @SuppressWarnings("fallthrough")
@@ -405,10 +425,16 @@ public class TopicPartitionWriter {
         }
       } catch (SchemaProjectorException | IllegalWorkerStateException | HiveMetaStoreException e) {
         throw new RuntimeException(e);
-      } catch (ConnectException e) {
+      } catch (AvroIOException | ConnectException e) {
         log.error("Exception on topic partition {}: ", tp, e);
         failureTime = time.milliseconds();
         setRetryTimeout(timeoutMs);
+        if (e instanceof AvroIOException) {
+          log.error("Encountered AVRO IO exception, resetting this topic partition {} "
+                  + "to offset {}", tp, offset);
+          resetAndSetRecovery();
+          return;
+        }
         break;
       }
     }
@@ -445,7 +471,7 @@ public class TopicPartitionWriter {
           default:
             log.error("{} is not a valid state to empty batch for topic partition {}.", state, tp);
         }
-      } catch (ConnectException e) {
+      } catch (AvroIOException | ConnectException e) {
         log.error("Exception on topic partition {}: ", tp, e);
         failureTime = time.milliseconds();
         setRetryTimeout(timeoutMs);
@@ -765,6 +791,7 @@ public class TopicPartitionWriter {
 
   private void closeTempFile() {
     ConnectException connectException = null;
+    AvroIOException avroException = null;
     for (String encodedPartition : tempFiles.keySet()) {
       // Close the file and propagate any errors
       try {
@@ -777,9 +804,18 @@ public class TopicPartitionWriter {
                 + " rewrite the temporary file.",
             encodedPartition
         );
+      } catch (AvroIOException e) {
+        log.error(
+                "Failed to close temporary file for partition {}. The connector will attempt to"
+                        + " rewrite the temporary file.",
+                encodedPartition
+        );
+        avroException = e;
       }
     }
-
+    if (avroException != null) {
+      throw avroException;
+    }
     if (connectException != null) {
       // at least one tmp file did not close properly therefore will try to recreate the tmp and
       // delete all buffered records + tmp files and start over because otherwise there will be

--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroIOException.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroIOException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.connect.hdfs.avro;
+
+import java.io.IOException;
+
+@SuppressWarnings("serial")
+public class AvroIOException extends RuntimeException {
+  public AvroIOException(IOException e) {
+    super(e);
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
@@ -22,8 +22,6 @@ import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +66,7 @@ public class AvroRecordWriterProvider
             writer.setCodec(CodecFactory.fromString(conf.getAvroCodec()));
             writer.create(avroSchema, out);
           } catch (IOException e) {
-            throw new ConnectException(e);
+            throw new AvroIOException(e);
           }
         }
 
@@ -82,7 +80,7 @@ public class AvroRecordWriterProvider
             writer.append(value);
           }
         } catch (IOException e) {
-          throw new DataException(e);
+          throw new AvroIOException(e);
         }
       }
 
@@ -91,7 +89,7 @@ public class AvroRecordWriterProvider
         try {
           writer.close();
         } catch (IOException e) {
-          throw new DataException(e);
+          throw new AvroIOException(e);
         }
       }
 

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -15,12 +15,14 @@
 
 package io.confluent.connect.hdfs.avro;
 
+import io.confluent.connect.hdfs.partitioner.DefaultPartitioner;
 import io.confluent.connect.hdfs.wal.FSWAL;
 import io.confluent.connect.hdfs.wal.WALFile.Writer;
 import io.confluent.connect.hdfs.wal.WALFileTest;
 import io.confluent.connect.hdfs.wal.WALFileTest.CorruptWriter;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -447,6 +449,82 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
 
     hdfsWriter.close();
     hdfsWriter.stop();
+  }
+
+  @Test
+  public void testRecoveryAfterFailedFlush() throws Exception {
+    // Define constants
+    String FLUSH_SIZE_CONFIG = "60";
+    int FLUSH_SIZE = Integer.valueOf(FLUSH_SIZE_CONFIG);
+    int NUMBER_OF_RECORDS = FLUSH_SIZE*2;
+    long SLEEP_TIME = 10000L;
+
+    // Create connector configs
+    Map<String, String> props = createProps();
+    props.put(HdfsSinkConnectorConfig.FLUSH_SIZE_CONFIG, FLUSH_SIZE_CONFIG);
+    props.put(
+            PartitionerConfig.PARTITIONER_CLASS_CONFIG,
+            DefaultPartitioner.class.getName()
+    );
+    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
+
+    // Initialize data writer
+    context.assignment().clear();
+    context.assignment().add(TOPIC_PARTITION);
+    Time time = TopicPartitionWriterTest.MockedWallclockTimestampExtractor.TIME;
+    DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData, time);
+    hdfsWriter.open(context.assignment());
+    partitioner = hdfsWriter.getPartitioner();
+
+    List<SinkRecord> sinkRecords = createSinkRecords(NUMBER_OF_RECORDS);
+
+    // Write initial batch of records
+    hdfsWriter.write(sinkRecords.subList(0, FLUSH_SIZE-2));
+
+    // Stop all datanodes
+    int NUM_DATANODES = 3;
+    ArrayList<MiniDFSCluster.DataNodeProperties> dnProps = new ArrayList<>();
+    for(int j=0; j<NUM_DATANODES; j++){
+      MiniDFSCluster.DataNodeProperties dnProp = cluster.stopDataNode(0);
+      dnProps.add(dnProp);
+    }
+
+    //  Attempt to write a batch of records that will result in a flush
+    hdfsWriter.write(sinkRecords.subList(FLUSH_SIZE-2, FLUSH_SIZE+2));
+    time.sleep(SLEEP_TIME);
+    // Simulate connect framework's effort to re-supply the lost data after offset reset
+    hdfsWriter.write(sinkRecords.subList(0, FLUSH_SIZE+2));
+    time.sleep(SLEEP_TIME);
+    hdfsWriter.write(sinkRecords.subList(0, FLUSH_SIZE+4));
+    time.sleep(SLEEP_TIME);
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+
+    //  Restart the datanodes and wait for them to come up
+    for(int j=0; j<NUM_DATANODES; j++){
+      cluster.restartDataNode(dnProps.get(j));
+    }
+    cluster.waitActive();
+
+    // assert that the offset was reset back to zero
+    assertEquals(0, hdfsWriter.getBucketWriter(TOPIC_PARTITION).offset());
+
+    // Simulate write attempts during recovery
+    hdfsWriter.write(sinkRecords.subList(0, NUMBER_OF_RECORDS));
+    time.sleep(SLEEP_TIME);
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+
+    // Assert that all records have been committed
+    Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedOffsets();
+    assertTrue(committedOffsets.containsKey(TOPIC_PARTITION));
+    long nextOffset = committedOffsets.get(TOPIC_PARTITION);
+    assertEquals(NUMBER_OF_RECORDS, nextOffset);
+
+    hdfsWriter.close();
+    hdfsWriter.stop();
+
+    // Assert that there are no zero data files
+    long[] validOffsets = {0, FLUSH_SIZE, FLUSH_SIZE*2};
+    verify(sinkRecords, validOffsets, Collections.singleton(TOPIC_PARTITION), false);
   }
 
   @Test


### PR DESCRIPTION
## Problem
A [change](https://issues.apache.org/jira/browse/AVRO-2109) was introduced into the avro writer where it resets its internal buffer of records on receiving an IOException. This differed from the earlier model where a IOException would not clear out the existing buffer. Due to this there is a potential for data loss in the connector as it does not rewrite the topic data into the buffer even on getting an IOException. Once the avro writer recovers the connector will flush the buffer and commit the offsets ignoring the previously missed data.


## Solution
This can only happen on the avro writer and the connector needs to rewind back the offsets of the topic partition and recover the buffer if such a situation arises. This PR addresses the changes required for this contingency by capturing the AVROIOException, rewinding the consumer offsets, and resetting any existing buffers to avoid pushing a duplicate data.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
