### PR TITLE
Ensure rotation of files based on rotation intervals

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -316,9 +316,9 @@ public class TopicPartitionWriter {
   private void updateRotationTimers(SinkRecord currentRecord) {
     long now = time.milliseconds();
     // Wallclock-based partitioners should be independent of the record argument.
-    lastRotate = isWallclockBased
+    lastRotate = isWallclockBased || currentRecord == null
                  ? (Long) now
-                 : currentRecord != null ? timestampExtractor.extract(currentRecord) : null;
+                 : timestampExtractor.extract(currentRecord);
     if (log.isDebugEnabled() && rotateIntervalMs > 0) {
       log.debug(
           "Update last rotation timer. Next rotation for {} will be in {}ms",
@@ -600,10 +600,10 @@ public class TopicPartitionWriter {
   }
 
   private boolean shouldRotateAndMaybeUpdateTimers(SinkRecord currentRecord, long now) {
-    Long currentTimestamp = null;
-    if (isWallclockBased) {
+    Long currentTimestamp;
+    if (isWallclockBased || currentRecord == null) {
       currentTimestamp = now;
-    } else if (currentRecord != null) {
+    } else {
       currentTimestamp = timestampExtractor.extract(currentRecord);
       lastRotate = lastRotate == null ? currentTimestamp : lastRotate;
     }


### PR DESCRIPTION
## Problem

https://github.com/confluentinc/kafka-connect-hdfs/issues/329

## Solution

By falling back to wallclock time when there is no record (i.e. when the upstream `DataWriter` calls `write()` while the buffer is empty) we initiate a rotation of tmp files to committed files if any of the time intervals trigger.

This change implies that we are not guaranteed to produce the same output for the same messages (i.e. replaying a topic). Replaying would, however, require one to delete all committed files and the WAL, as the connector uses those to persist offsets, thus by itself this is not a concern.