### PR TITLE
CVE Fixes: Avro, Netty, Zookeeper, Compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.3</version>
+        <version>11.2.9</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -62,7 +62,7 @@
         <complexity.coverage.threshold>0.53</complexity.coverage.threshold>
         <line.coverage.threshold>0.66</line.coverage.threshold>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>11.2.3</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>11.2.9</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons-net.version>3.9.0</commons-net.version>
         <ivy.version>2.5.2</ivy.version>
@@ -146,6 +146,11 @@
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
                 <version>${snappy.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>3.7.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-22821
https://confluentinc.atlassian.net/browse/CC-22940
https://confluentinc.atlassian.net/browse/CC-23101
https://confluentinc.atlassian.net/browse/CC-23261
https://confluentinc.atlassian.net/browse/CC-25320

Docker Playground Test: https://github.com/confluentinc/kafka-connect-hdfs/pull/688#issuecomment-2007807860

```
Twistlock Scan
 jar	 critical	org.apache.hadoop_hadoop-hdfs version 2.10.2 has 1 vulnerability
 jar	 critical	org.apache.hadoop_hadoop-common version 2.10.2 has 1 vulnerability
 jar	 critical	org.apache.calcite_calcite-core version 1.11.0 has 2 vulnerabilities
 jar	 high	org.xerial.snappy_snappy-java version 1.1.10 has 4 vulnerabilities <--- Twistlock does not pick up nano-versions. This has already been fixed
 jar	 high	org.apache.thrift_libthrift version 0.13.0 has 1 vulnerability
 jar	 high	org.apache.calcite.avatica_avatica-core version 1.9.0 has 1 vulnerability
 jar	 moderate	org.apache.zookeeper_zookeeper version 3.7.2 has 1 vulnerability
 jar	 medium	org.apache.commons.httpclient_commons-httpclient version 3.1 has 1 vulnerability
 jar	 moderate	org.apache.calcite_calcite-druid version 1.11.0 has 1 vulnerability
 jar	 moderate	com.squareup.okio_okio version 1.6.0 has 1 vulnerability
 jar	 moderate	com.nimbusds_nimbus-jose-jwt version 7.9 has 1 vulnerability
 jar	 medium	com.fasterxml.jackson.core_jackson-databind version 2.15.2 has 1 vulnerability
```
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
