### PR TITLE
Revert release version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
-    <version>10.2.13-SNAPSHOT</version>
+    <version>10.2.12-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>kafka-connect-hdfs</name>
     <organization>


### PR DESCRIPTION
## Problem
v10.2.12 release failed midway through the process, and v10.2.12 was not made available on the confluent hub.

## Solution
Revert the snapshot version to `v10.2.12-SNAPSHOT` and re-attempt the release.
