### PR TITLE
Incremental Co-operative Rebalancing Support for HDFS Connector (#625)

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -465,15 +465,12 @@ public class DataWriter {
   }
 
   public void close() {
-    // Close any writers we have. We may get assigned the same partitions and end up duplicating
-    // some effort since we'll have to reprocess those messages. It may be possible to hold on to
-    // the TopicPartitionWriter and continue to use the temp file, but this can get significantly
-    // more complex due to potential failures and network partitions. For example, we may get
-    // this close, then miss a few generations of group membership, during which
-    // data may have continued to be processed and we'd have to restart from the recovery stage,
-    // make sure we apply the WAL, and only reuse the temp file if the starting offset is still
-    // valid. For now, we prefer the simpler solution that may result in a bit of wasted effort.
-    for (TopicPartitionWriter writer : topicPartitionWriters.values()) {
+    close(new HashSet<>(topicPartitionWriters.keySet()));
+  }
+
+  public void close(Collection<TopicPartition> partitions) {
+    for (TopicPartition partition: partitions) {
+      TopicPartitionWriter writer = topicPartitionWriters.get(partition);
       try {
         if (writer != null) {
           // In some failure modes, the writer might not have been created for all assignments
@@ -482,8 +479,8 @@ public class DataWriter {
       } catch (ConnectException e) {
         log.warn("Unable to close writer for topic partition {}: ", writer.topicPartition(), e);
       }
+      topicPartitionWriters.remove(partition);
     }
-    topicPartitionWriters.clear();
   }
 
   public void stop() {

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkTask.java
@@ -166,7 +166,7 @@ public class HdfsSinkTask extends SinkTask {
   public void close(Collection<TopicPartition> partitions) {
     log.debug("Closing HDFS Sink Task {}", connectorNameAndTaskId);
     if (hdfsWriter != null) {
-      hdfsWriter.close();
+      hdfsWriter.close(partitions);
     }
   }
 


### PR DESCRIPTION
This is a copy of https://github.com/confluentinc/kafka-connect-hdfs/pull/711, but from my personal email, with which I can sign the CLA.

## Problem
See https://github.com/confluentinc/kafka-connect-hdfs/issues/625.
If `consumer.partition.assignment.strategy` is set to `org.apache.kafka.clients.consumer.CooperativeStickyAssignor` in `config/connect-distributed.properties`, after a partial partition revocation (say, a new worker joins and takes over some partitions from some other worker) in a task it will be killed due to such `NullPointerException`:
```
[2024-11-15 13:46:37,190] ERROR [hdfs-sink-2|task-1] WorkerSinkTask{id=hdfs-sink-2-1} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted (org.apache.kafka.connect.runtime.WorkerTask:212)
org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
        at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:632)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:350)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:250)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:219)
        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:204)
        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:259)
        at org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$1(Plugins.java:237)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.NullPointerException
        at io.confluent.connect.hdfs.DataWriter.write(DataWriter.java:364)
        at io.confluent.connect.hdfs.HdfsSinkTask.put(HdfsSinkTask.java:133)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:601)
        ... 11 more
```
The reason for that is that during `onPartitionsRevoked` callback the `DataWriter` currently closes and [removes](https://github.com/confluentinc/kafka-connect-hdfs/blob/master/src/main/java/io/confluent/connect/hdfs/DataWriter.java#L486) all of its `TopicPartitionWriter`s, probably assuming eager rebalancing. 
If the consumer only gets some partitions revoked and none new assigned, the `onPartitionsAssigned` will be called with empty collection and the `topicPartitionWriters` collection will remain empty.
When new data arrives (from partitions that the consumer kept ownership of) to `HdfsSinkTask#put`, the `NullPointerException` will be thrown when [accessing](https://github.com/confluentinc/kafka-connect-hdfs/blob/master/src/main/java/io/confluent/connect/hdfs/DataWriter.java#L364) the `topicPartitionsWriters`.

## Solution
Only close and remove from `topicPartitionsWriters` those partitions retrieved from `HdfsSinkTask#close(Collection<TopicPartition>)`.
**Note**: there is a 9 years old [comment](https://github.com/confluentinc/kafka-connect-hdfs/blob/master/src/main/java/io/confluent/connect/hdfs/DataWriter.java#L468-L475) explaining why should we close _all_ of the topic partition writers, which I didn't really understand. This solution simply ignores and removes it. @ewencp, can you please review and put some comments if it would be safe to do so?

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Added `HdfsSinkTaskTest#testPartialRevocation` unit test simulating a partial revocation that throws `NullPointerException` without the fix.
Plus, tested manually (after adding a second worker (partial revocation happens) and writing some data to topic no NPE is thrown).

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
Please see a similar issue for Connect framework itself, [KAFKA-12487](https://issues.apache.org/jira/browse/KAFKA-12487). I was testing the fix on Kafka `7.7.2-18-ccs` where this fix is already present, but haven't tested on earlier versions without it. Should I do it?