### PR TITLE
CC-32379: Use RE2/J to address Potential ReDOS vulnerability in java.util.regex

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.hdfs;
 
+import com.google.re2j.Matcher;
+
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -27,7 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Matcher;
 
 import io.confluent.connect.hdfs.filter.CommittedFileFilter;
 import io.confluent.connect.hdfs.storage.Storage;

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -15,12 +15,12 @@
 
 package io.confluent.connect.hdfs;
 
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
+import com.google.re2j.PatternSyntaxException;
 import io.confluent.connect.hdfs.orc.OrcFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import io.confluent.connect.hdfs.parquet.ParquetFormat;
 import io.confluent.connect.hdfs.string.StringFormat;
 import org.apache.commons.lang.StringUtils;
@@ -402,10 +402,14 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
     this.url = extractUrl();
     try {
       String topicRegex = getString(TOPIC_CAPTURE_GROUPS_REGEX_CONFIG);
-      this.topicRegexCaptureGroup = topicRegex != null ? Pattern.compile(topicRegex) : null;
+      if (topicRegex != null) {
+        this.topicRegexCaptureGroup = Pattern.compile(topicRegex);
+      } else {
+        this.topicRegexCaptureGroup = null;
+      }
     } catch (PatternSyntaxException e) {
       throw new ConfigException(
-          TOPIC_CAPTURE_GROUPS_REGEX_CONFIG + " is an invalid regex pattern: ",
+          TOPIC_CAPTURE_GROUPS_REGEX_CONFIG + " is an invalid regex pattern: " + e.getMessage(),
           e
       );
     }

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConstants.java
@@ -15,7 +15,7 @@
 
 package io.confluent.connect.hdfs;
 
-import java.util.regex.Pattern;
+import com.google.re2j.Pattern;
 
 public class HdfsSinkConnectorConstants {
 

--- a/src/main/java/io/confluent/connect/hdfs/filter/CommittedFileFilter.java
+++ b/src/main/java/io/confluent/connect/hdfs/filter/CommittedFileFilter.java
@@ -17,11 +17,9 @@ package io.confluent.connect.hdfs.filter;
 
 import io.confluent.connect.hdfs.HdfsSinkConnectorConstants;
 
+import com.google.re2j.Matcher;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
-
-import java.util.regex.Matcher;
-
 
 public class CommittedFileFilter implements PathFilter {
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/filter/TopicCommittedFileFilter.java
+++ b/src/main/java/io/confluent/connect/hdfs/filter/TopicCommittedFileFilter.java
@@ -15,11 +15,10 @@
 
 package io.confluent.connect.hdfs.filter;
 
+import com.google.re2j.Matcher;
 import org.apache.hadoop.fs.Path;
 
 import io.confluent.connect.hdfs.HdfsSinkConnectorConstants;
-
-import java.util.regex.Matcher;
 
 public class TopicCommittedFileFilter extends CommittedFileFilter {
   private String topic;

--- a/src/main/java/io/confluent/connect/hdfs/filter/TopicPartitionCommittedFileFilter.java
+++ b/src/main/java/io/confluent/connect/hdfs/filter/TopicPartitionCommittedFileFilter.java
@@ -15,10 +15,9 @@
 
 package io.confluent.connect.hdfs.filter;
 
+import com.google.re2j.Matcher;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
-
-import java.util.regex.Matcher;
 
 import io.confluent.connect.hdfs.HdfsSinkConnectorConstants;
 


### PR DESCRIPTION
## Problem
Potential ReDOS vulnerability from user-supplied data in java.util.regex in HdfsSinkConnectorConfig.java

## Solution
Utilizing RE2/J, the Java implementation of the RE2 regular expression engine, as one of the recommended approaches outlined in the ticket.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Docker playground test with config: `"topic.capture.groups.regex": "^(.+)-(\\\\d{4})-(\\\\d{2})-(\\\\d{2})$"`
```
 limit 10;ve2://hive-server:10000/testhive> select * from app_metrics_2025_05_21 
+----------------------------+-----------------------------------+
| app_metrics_2025_05_21.f1  | app_metrics_2025_05_21.partition  |
+----------------------------+-----------------------------------+
| value1                     | 0                                 |
| value2                     | 0                                 |
| value3                     | 0                                 |
| value4                     | 0                                 |
| value5                     | 0                                 |
| value6                     | 0                                 |
| value7                     | 0                                 |
| value8                     | 0                                 |
| value9                     | 0                                 |
+----------------------------+-----------------------------------+
9 rows selected (1.618 seconds)
0: jdbc:hive2://hive-server:10000/testhive> Closing: 0: jdbc:hive2://hive-server:10000/testhive
| value1                     | 0                                 |
12:14:40 ℹ️ Found 'value1' in Hive query result.
12:14:40 ℹ️ Test completed successfully!
12:14:40 ℹ️ ####################################################
12:14:40 ℹ️ ✅ RESULT: SUCCESS for hdfs2-sink.sh (took: 2min 19sec - )
12:14:40 ℹ️ ####################################################

12:14:45 ℹ️ 🧩 Displaying status for 🌎onprem connector hdfs-sink
Name                           Status       Tasks                                                        Stack Trace                                       
-------------------------------------------------------------------------------------------------------------
hdfs-sink                      ✅ RUNNING  0:🟢 RUNNING[connect]        -                                                 
-------------------------------------------------------------------------------------------------------------
12:14:46 ℹ️ 🌐 documentation is available at:
https://docs.confluent.io/current/connect/kafka-connect-hdfs/index.html
```

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
