### PR TITLE
Bump dependencies to resolve CVE-2025-46762, CVE-2024-13009, CVE-2023-51074

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.22</version>
+        <version>11.2.24</version>
     </parent>
 
     <artifactId>kafka-connect-hdfs</artifactId>
@@ -62,7 +62,7 @@
         <complexity.coverage.threshold>0.53</complexity.coverage.threshold>
         <line.coverage.threshold>0.66</line.coverage.threshold>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <kafka.connect.storage.common.version>11.2.22</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>11.2.24</kafka.connect.storage.common.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons-net.version>3.9.0</commons-net.version>
         <ivy.version>2.5.2</ivy.version>


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-33759
https://confluentinc.atlassian.net/browse/CC-33758
https://confluentinc.atlassian.net/browse/CC-30700


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

```
14:52:58 ℹ️ Creating HDFS Sink connector
14:52:59 ℹ️ 🛠️ Creating 🌎onprem connector hdfs-sink
14:53:00 ℹ️ 📋 🌎onprem connector config has been copied to the clipboard (disable with 'playground config set clipboard false')
14:53:00 ℹ️ ✅ 🌎onprem connector hdfs-sink was successfully created
14:53:00 ℹ️ 🧰 Current config for 🌎onprem connector hdfs-sink (using REST API /config endpoint)
playground connector create-or-update --connector hdfs-sink --no-clipboard << EOF
{
  "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
  "flush.size": "3",
  "format.class": "io.confluent.connect.hdfs.parquet.ParquetFormat",
  "hadoop.conf.dir": "/etc/hadoop/",
  "hive.database": "testhive",
  "hive.integration": "true",
  "hive.metastore.uris": "thrift://hive-metastore:9083",
  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
  "logs.dir": "/tmp",
  "name": "hdfs-sink",
  "partitioner.class": "io.confluent.connect.storage.partitioner.DefaultPartitioner",
  "rotate.interval.ms": "120000",
  "schema.compatibility": "BACKWARD",
  "store.url": "hdfs://namenode:8020",
  "tasks.max": "1",
  "topics": "test_hdfs",
  "value.converter": "io.confluent.connect.avro.AvroConverter",
  "value.converter.schema.registry.url": "http://schema-registry:8081"
}
EOF
14:53:02 ℹ️ 🔩 list of all available parameters for 🌎onprem connector hdfs-sink (io.confluent.connect.hdfs.HdfsSinkConnector) and version 10.2.15-SNAPSHOT (with default value when applicable)
    "allow.optional.map.keys": "false",
    "avro.codec": "",
    "connect.hdfs.keytab": "STRING",
    "connect.hdfs.principal": "STRING",
    "connect.meta.data": "true",
    "directory.delim": "/",
    "enhanced.avro.schema.support": "true",
    "file.delim": "+",
    "filename.offset.zero.pad.width": "10",
    "flush.size": "",
    "format.class": "io.confluent.connect.hdfs.avro.AvroFormat",
    "hadoop.conf.dir": "STRING",
    "hadoop.home": "STRING",
    "hdfs.authentication.kerberos": "false",
    "hdfs.namenode.principal": "STRING",
    "hdfs.url": "",
    "hive.conf.dir": "STRING",
    "hive.database": "default",
    "hive.home": "STRING",
    "hive.integration": "false",
    "hive.metastore.uris": "STRING",
    "hive.table.name": "${topic}",
    "kerberos.ticket.renew.period.ms": "3600000",
    "locale": "STRING",
    "logs.dir": "logs",
    "partition.duration.ms": "-1",
    "partition.field.name": "LIST",
    "partitioner.class": "io.confluent.connect.storage.partitioner.DefaultPartitioner",
    "path.format": "STRING",
    "retry.backoff.ms": "5000",
    "rotate.interval.ms": "-1",
    "rotate.schedule.interval.ms": "-1",
    "schema.compatibility": "NONE",
    "schemas.cache.config": "1000",
    "shutdown.timeout.ms": "3000",
    "storage.class": "io.confluent.connect.hdfs.storage.HdfsStorage",
    "store.url": "",
    "timestamp.extractor": "Wallclock",
    "timestamp.field": "timestamp",
    "timezone": "STRING",
    "topic.capture.groups.regex": "",
    "topics.dir": "topics",
14:53:04 ℹ️ 🥁 Waiting a few seconds to get new status
14:53:10 ℹ️ 🧩 Displaying status for 🌎onprem connector hdfs-sink
Name                           Status       Tasks                                                        Stack Trace
-------------------------------------------------------------------------------------------------------------
hdfs-sink                      ✅ RUNNING  0:🟢 RUNNING[connect]        -
-------------------------------------------------------------------------------------------------------------
14:53:11 ℹ️ 🌐 documentation for 🌎onprem connector kafka-connect-hdfs is available at:
https://docs.confluent.io/kafka-connect-hdfs/current/index.html
14:53:11 ℹ️ Sending messages to topic test_hdfs
14:53:12 ℹ️ 🔮 value schema was identified as avro
14:53:12 ℹ️ ✨ generating value data...
14:53:12 ℹ️ ☢️ --forced-value is set
14:53:12 ℹ️ ✨ 10 records were generated based on --forced-value  (only showing first 10), took: 0min 0sec
{"f1":"value1"}
{"f1":"value2"}
{"f1":"value3"}
{"f1":"value4"}
{"f1":"value5"}
{"f1":"value6"}
{"f1":"value7"}
{"f1":"value8"}
{"f1":"value9"}
{"f1":"value10"}
14:53:13 ℹ️ 📤 producing 10 records to topic test_hdfs
14:53:15 ℹ️ 📤 produced 10 records to topic test_hdfs, took: 0min 2sec
14:53:25 ℹ️ Listing content of /topics/test_hdfs/partition=0 in HDFS
Found 3 items
-rw-r--r--   3 appuser supergroup        486 2025-06-04 09:23 /topics/test_hdfs/partition=0/test_hdfs+0+0000000000+0000000002.parquet
-rw-r--r--   3 appuser supergroup        486 2025-06-04 09:23 /topics/test_hdfs/partition=0/test_hdfs+0+0000000003+0000000005.parquet
-rw-r--r--   3 appuser supergroup        486 2025-06-04 09:23 /topics/test_hdfs/partition=0/test_hdfs+0+0000000006+0000000008.parquet
14:53:27 ℹ️ Getting one of the avro files locally and displaying content with avro-tools
Successfully copied 2.05kB to /tmp/
14:53:30 ℹ️ 🔖 test_hdfs+0+0000000000+0000000002.parquet.parquet schema
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
message myrecord {
  required binary f1 (STRING);
}

14:53:31 ℹ️ 🔖 test_hdfs+0+0000000000+0000000002.parquet.parquet content
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
f1 = value1

f1 = value2

f1 = value3

14:53:33 ℹ️ ####################################################
14:53:33 ℹ️ ✅ RESULT: SUCCESS for hdfs2-sink.sh (took: 1min 42sec - )
14:53:33 ℹ️ ####################################################

14:53:37 ℹ️ 🧩 Displaying status for 🌎onprem connector hdfs-sink
Name                           Status       Tasks                                                        Stack Trace
-------------------------------------------------------------------------------------------------------------
hdfs-sink                      ✅ RUNNING  0:🟢 RUNNING[connect]        -
-------------------------------------------------------------------------------------------------------------
```

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
