### PR TITLE
CC-34816: Bump jersey-core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-core</artifactId>
+            <version>1.13</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
             <version>${kafka.version}</version>


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-34816

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

```
Name                           Status       Tasks                                                        Stack Trace
-------------------------------------------------------------------------------------------------------------
hdfs-sink                      ✅ RUNNING  0:🟢 RUNNING[connect]        -
-------------------------------------------------------------------------------------------------------------
11:21:00 ℹ️ 🌐 documentation for 🌎onprem connector kafka-connect-hdfs is available at:
https://docs.confluent.io/kafka-connect-hdfs/current/index.html
11:21:00 ℹ️ Sending messages to topic test_hdfs
11:21:01 ℹ️ 🔮 value schema was identified as avro
11:21:01 ℹ️ ✨ generating value data...
11:21:01 ℹ️ ☢️ --forced-value is set
11:21:01 ℹ️ ✨ 10 records were generated based on --forced-value  (only showing first 10), took: 0min 0sec
{"f1":"value1"}
{"f1":"value2"}
{"f1":"value3"}
{"f1":"value4"}
{"f1":"value5"}
{"f1":"value6"}
{"f1":"value7"}
{"f1":"value8"}
{"f1":"value9"}
{"f1":"value10"}
11:21:03 ℹ️ 📤 producing 10 records to topic test_hdfs
11:21:04 ℹ️ 📤 produced 10 records to topic test_hdfs, took: 0min 1sec
11:21:14 ℹ️ Listing content of /topics/test_hdfs/partition=0 in HDFS
Found 3 items
-rw-r--r--   3 appuser supergroup        486 2025-07-18 05:51 /topics/test_hdfs/partition=0/test_hdfs+0+0000000000+0000000002.parquet
-rw-r--r--   3 appuser supergroup        486 2025-07-18 05:51 /topics/test_hdfs/partition=0/test_hdfs+0+0000000003+0000000005.parquet
-rw-r--r--   3 appuser supergroup        486 2025-07-18 05:51 /topics/test_hdfs/partition=0/test_hdfs+0+0000000006+0000000008.parquet
11:21:16 ℹ️ Getting one of the avro files locally and displaying content with avro-tools
Successfully copied 2.05kB to /tmp/
11:21:19 ℹ️ 🔖 test_hdfs+0+0000000000+0000000002.parquet.parquet schema
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
message myrecord {
  required binary f1 (STRING);
}

11:21:21 ℹ️ 🔖 test_hdfs+0+0000000000+0000000002.parquet.parquet content
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
f1 = value1

f1 = value2

f1 = value3

11:21:22 ℹ️ ####################################################
11:21:22 ℹ️ ✅ RESULT: SUCCESS for hdfs2-sink.sh (took: 1min 41sec - )
11:21:22 ℹ️ ####################################################

11:21:27 ℹ️ 🧩 Displaying status for 🌎onprem connector hdfs-sink
Name                           Status       Tasks                                                        Stack Trace
-------------------------------------------------------------------------------------------------------------
hdfs-sink                      ✅ RUNNING  0:🟢 RUNNING[connect]        -
-------------------------------------------------------------------------------------------------------------
```

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
