### PR TITLE
DP-17858 - Add github write targets

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -13,6 +13,8 @@ semaphore:
   generate_connect_changelogs: true
   trivy_scan: true
   run_pint_merge: true
+  github_write_targets:
+    - confluentinc/docs-kafka-connect-hdfs
 code_artifact:
   enable: true
   package_paths:


### PR DESCRIPTION
### Background
Starting February 2nd, Semaphore project must declare their write targets in service.yml file in order to perform cross-repo writes. 

### What's New?
* Added github_write_targets to the semaphore plugin in service.yml: These targets (GitHub repos) were automatically generated based on Semaphore audit logs. If these targets are incorrect or incomplete, please update the file accordingly.
